### PR TITLE
Include satellites above altitude beam width

### DIFF
--- a/satellite_determination/event_finder/event_finder_rhodesmill/support/satellites_within_main_beam_filter.py
+++ b/satellite_determination/event_finder/event_finder_rhodesmill/support/satellites_within_main_beam_filter.py
@@ -70,8 +70,9 @@ class SatellitesWithinMainBeamFilter:
 
     def _is_within_beam_width_altitude(self, satellite_altitude: float, antenna_altitude: float) -> bool:
         is_above_horizon = satellite_altitude >= 0
-        is_within_beam_width = isclose(satellite_altitude, antenna_altitude, abs_tol=self._facility.half_beamwidth)
-        return is_above_horizon and is_within_beam_width
+        lowest_main_beam_altitude = antenna_altitude - self._facility.half_beamwidth
+        is_above_main_beam_altitude = satellite_altitude >= lowest_main_beam_altitude
+        return is_above_horizon and is_above_main_beam_altitude
 
     def _is_within_beam_with_azimuth(self, satellite_azimuth: float, antenna_azimuth: float) -> bool:
         positions_to_compare_original = [satellite_azimuth, antenna_azimuth]

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter.py
@@ -31,18 +31,6 @@ class TestSatellitesWithinMainBeam:
         windows = slew.run()
         assert windows == [TimeWindow(begin=ARBITRARY_ANTENNA_POSITION.time, end=cutoff_time)]
 
-    def test_one_satellite_position_outside_beamwidth_altitude(self):
-        satellite_positions = [
-            replace(ARBITRARY_ANTENNA_POSITION,
-                    altitude=ARBITRARY_ANTENNA_POSITION.altitude - self._value_slightly_larger_than_half_beamwidth)
-        ]
-        slew = SatellitesWithinMainBeamFilter(facility=ARBITRARY_FACILITY,
-                                              antenna_positions=[AntennaPosition(satellite_positions=satellite_positions,
-                                                                                 antenna_direction=ARBITRARY_ANTENNA_POSITION)],
-                                              cutoff_time=self._arbitrary_cutoff_time)
-        windows = slew.run()
-        assert windows == []
-
     def test_one_satellite_position_outside_beamwidth_azimuth(self):
         satellite_positions = [
             replace(ARBITRARY_ANTENNA_POSITION,
@@ -56,7 +44,7 @@ class TestSatellitesWithinMainBeam:
         assert windows == []
 
     def test_one_satellite_with_multiple_sequential_positions_in_view(self):
-        out_of_altitude = ARBITRARY_ANTENNA_POSITION.altitude + self._value_slightly_larger_than_half_beamwidth
+        out_of_altitude = ARBITRARY_ANTENNA_POSITION.altitude - self._value_slightly_larger_than_half_beamwidth
         satellite_positions = [
             replace(ARBITRARY_ANTENNA_POSITION,
                     altitude=out_of_altitude if i == 2 else ARBITRARY_ANTENNA_POSITION.altitude,
@@ -75,7 +63,7 @@ class TestSatellitesWithinMainBeam:
         ]
 
     def test_one_satellite_with_multiple_sequential_positions_out_of_view(self):
-        out_of_altitude = ARBITRARY_ANTENNA_POSITION.altitude + self._value_slightly_larger_than_half_beamwidth
+        out_of_altitude = ARBITRARY_ANTENNA_POSITION.altitude - self._value_slightly_larger_than_half_beamwidth
         satellite_positions = [
             replace(ARBITRARY_ANTENNA_POSITION,
                     altitude=out_of_altitude if 0 < i < 3 else ARBITRARY_ANTENNA_POSITION.altitude,
@@ -96,7 +84,7 @@ class TestSatellitesWithinMainBeam:
 
     @property
     def _value_slightly_larger_than_half_beamwidth(self) -> float:
-        return ARBITRARY_FACILITY.beamwidth - SMALL_EPSILON
+        return ARBITRARY_FACILITY.half_beamwidth + SMALL_EPSILON
 
     def test_one_satellite_below_horizon_but_within_beamwidth(self):
         antenna_position_at_horizon = replace(ARBITRARY_ANTENNA_POSITION, altitude=0)

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_altitude.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_altitude.py
@@ -1,0 +1,43 @@
+from dataclasses import replace
+from datetime import datetime
+from functools import cached_property
+from typing import List
+
+import pytz
+
+from satellite_determination.custom_dataclasses.time_window import TimeWindow
+from satellite_determination.event_finder.event_finder_rhodesmill.support.satellites_within_main_beam_filter import SatellitesWithinMainBeamFilter, \
+    AntennaPosition
+from tests.definitions import SMALL_EPSILON
+from tests.event_finder.event_finder_rhodesmill.definitions import ARBITRARY_ANTENNA_POSITION, ARBITRARY_FACILITY
+
+
+class TestSatellitesWithinMainBeamAltitude:
+    def test_one_satellite_position_below_beamwidth_altitude(self):
+        self._run_test(altitude=ARBITRARY_ANTENNA_POSITION.altitude - self._value_slightly_larger_than_half_beamwidth,
+                       expected_windows=[])
+
+    def test_one_satellite_position_above_beamwidth_altitude(self):
+        self._run_test(altitude=ARBITRARY_ANTENNA_POSITION.altitude + self._value_slightly_larger_than_half_beamwidth,
+                       expected_windows=[TimeWindow(begin=ARBITRARY_ANTENNA_POSITION.time, end=self._arbitrary_cutoff_time)])
+
+    def _run_test(self, altitude: float, expected_windows: List[TimeWindow]) -> None:
+        satellite_positions = [
+            replace(ARBITRARY_ANTENNA_POSITION,
+                    altitude=altitude)
+        ]
+        slew = SatellitesWithinMainBeamFilter(facility=ARBITRARY_FACILITY,
+                                              antenna_positions=[
+                                                  AntennaPosition(satellite_positions=satellite_positions,
+                                                                  antenna_direction=ARBITRARY_ANTENNA_POSITION)],
+                                              cutoff_time=self._arbitrary_cutoff_time)
+        windows = slew.run()
+        assert windows == expected_windows
+
+    @property
+    def _value_slightly_larger_than_half_beamwidth(self) -> float:
+        return ARBITRARY_FACILITY.half_beamwidth + SMALL_EPSILON
+
+    @cached_property
+    def _arbitrary_cutoff_time(self) -> datetime:
+        return datetime.now(tz=pytz.UTC)

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_unsorted_satellite_positions.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_unsorted_satellite_positions.py
@@ -35,8 +35,8 @@ class TestSatellitesWithinMainBeamOneAntennaPositionMultipleSatellitePositions:
 
     @cached_property
     def _satellite_positions_by_time_ascending(self) -> List[PositionTime]:
-        value_slightly_larger_than_half_beam_width = ARBITRARY_FACILITY.beamwidth - SMALL_EPSILON
-        out_of_altitude = ARBITRARY_ANTENNA_POSITION.altitude + value_slightly_larger_than_half_beam_width
+        value_slightly_larger_than_half_beam_width = ARBITRARY_FACILITY.half_beamwidth + SMALL_EPSILON
+        out_of_altitude = ARBITRARY_ANTENNA_POSITION.altitude - value_slightly_larger_than_half_beam_width
         return [
             replace(ARBITRARY_ANTENNA_POSITION,
                     altitude=out_of_altitude if i % 2 else ARBITRARY_ANTENNA_POSITION.altitude,


### PR DESCRIPTION
This includes satellites that are above the lowest main beam altitude as interferers, since even being out of the main beam, they may still cause interference when their transmissions intersect with the main beam.

This resolves #40.