### PR TITLE
Separate observation target from facility in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,34 +57,42 @@ The following is an example of a config file:
     [RESERVATION]
     Latitude=40.8178049
     Longitude=-121.4695413
-    RightAscension=4h42m
-    Declination=-38d6m50.8s
     Beamwidth=3
     Name=HCRO
     StartTimeUTC=2023-03-30T10:00:00.000000
     EndTimeUTC=2023-03-30T15:00:00.000000
     Frequency=135
     Bandwidth=10
-    SearchWindowStart=2023-03-30T10:00:00.000000
-    SearchWindowEnd=2023-03-30T15:00:00.000000
+    
+    [OBSERVATION TARGET]
+    Declination=-38d6m50.8s
+    Right Ascension=4h42m
+
 
 Below is a description of each of these values:
 + Latitude is the latitude of the RA facility
 + Longitude is the longitude of the RA facility
-+ RightAscension is the right ascension value of the celestial target the RA telescope is trying to observe
-  + More information can be found in [Astropy's Astronomical Coordinate System](https://docs.astropy.org/en/stable/coordinates/index.html)
-+ Declination is the declination value of the celestial target the RA telescope is trying to observe
-  + More information can be found in [Astropy's Astronomical Coordinate System](https://docs.astropy.org/en/stable/coordinates/index.html)
 + Beamwidth is the beamwidth of the RA telescope
 + Name is the name of the RA facility
 + StartTimeUTC is the desired start time of the observation in UTC
 + EndTimeUTC is the desired end time of the observation in UTC
 + Frequency is the center frequency of the observation
 + Bandwidth is the bandwidth of the desired observation
-+ SearchWindowStart and SearchWindowEnd are the start and end times, in UTC, for SOPP to conduct its search for potential
-  interference. For instance, the target may be visible in the sky for eight hours but only an hour observation is 
-  needed. By providing SOPP the entire eight hour period that the target is visible, it will search through this entire 
-  window to find the hours with the least interference.
+
++ Declination is the declination value of the celestial target the RA telescope is trying to observe
+  + More information can be found in [Astropy's Astronomical Coordinate System](https://docs.astropy.org/en/stable/coordinates/index.html)
++ RightAscension is the right ascension value of the celestial target the RA telescope is trying to observe
+  + More information can be found in [Astropy's Astronomical Coordinate System](https://docs.astropy.org/en/stable/coordinates/index.html)
+
+
+###### Static Antenna Position
+A static antenna position may be given instead of an observation target's declination and right ascension.
+The following is an example config file portion. If both a static antenna position and an observation target is given,
+the static antenna position will take precedence.
+    
+    [STATIC ANTENNA POSITION]
+    Altitude=0.2
+    Azimuth=0.3
 
 ### Run command
 In the root directory, run the following command:

--- a/satellite_determination/config_file.py
+++ b/satellite_determination/config_file.py
@@ -1,11 +1,14 @@
-from configparser import ConfigParser, SectionProxy
+from configparser import ConfigParser
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
 
+from satellite_determination.custom_dataclasses.configuration import Configuration
 from satellite_determination.custom_dataclasses.coordinates import Coordinates
 from satellite_determination.custom_dataclasses.facility import Facility
 from satellite_determination.custom_dataclasses.frequency_range.frequency_range import FrequencyRange
+from satellite_determination.custom_dataclasses.observation_target import ObservationTarget
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.reservation import Reservation
 from satellite_determination.custom_dataclasses.time_window import TimeWindow
 from satellite_determination.utilities import convert_datetime_to_utc, get_default_config_file_filepath
@@ -18,38 +21,55 @@ class ConfigFile:
     def __init__(self, filepath: Path = get_default_config_file_filepath()):
         self._filepath = filepath
 
-    @property
-    def reservation(self) -> Reservation:
-        start_datetime = self._read_datetime_as_utc('StartTimeUTC')
-        end_datetime_str = self._read_datetime_as_utc('EndTimeUTC')
+    @cached_property
+    def configuration(self) -> Configuration:
+        return Configuration(
+            reservation=self._reservation,
+            observation_target=self._observation_target,
+            static_antenna_position=self._static_antenna_position
+        )
+
+    @cached_property
+    def _reservation(self) -> Reservation:
+        configuration = self._config_object['RESERVATION']
+        start_datetime = self._read_datetime_as_utc(configuration['StartTimeUTC'])
+        end_datetime_str = self._read_datetime_as_utc(configuration['EndTimeUTC'])
         return Reservation(
             facility=Facility(
-                right_ascension=self._reservation_parameters['RightAscension'],
-                coordinates=Coordinates(latitude=float(self._reservation_parameters['Latitude']),
-                                        longitude=float(self._reservation_parameters['Longitude'])),
-                name=self._reservation_parameters['Name'],
-                declination=self._reservation_parameters['Declination'],
+                coordinates=Coordinates(latitude=float(configuration['Latitude']),
+                                        longitude=float(configuration['Longitude'])),
+                name=configuration['Name'],
             ),
             time=TimeWindow(begin=start_datetime, end=end_datetime_str),
             frequency=FrequencyRange(
-                frequency=float(self._reservation_parameters['Frequency']),
-                bandwidth=float(self._reservation_parameters['Bandwidth'])
+                frequency=float(configuration['Frequency']),
+                bandwidth=float(configuration['Bandwidth'])
             )
         )
 
-    @property
-    def search_window(self) -> TimeWindow:
-        search_window_start = self._read_datetime_as_utc('SearchWindowStart')
-        search_window_end = self._read_datetime_as_utc('SearchWindowEnd')
-        return TimeWindow(begin=search_window_start, end=search_window_end)
-
-    def _read_datetime_as_utc(self, key: str) -> datetime:
-        string_value = self._reservation_parameters[key]
+    @staticmethod
+    def _read_datetime_as_utc(string_value: str) -> datetime:
         without_timezone = datetime.strptime(string_value, TIME_FORMAT)
         return convert_datetime_to_utc(without_timezone)
 
     @cached_property
-    def _reservation_parameters(self) -> SectionProxy:
+    def _observation_target(self) -> ObservationTarget:
+        observation_target_parameters = self._config_object['OBSERVATION TARGET']
+        return ObservationTarget(
+            declination=observation_target_parameters['Declination'],
+            right_ascension=observation_target_parameters['Right Ascension']
+        )
+
+    @cached_property
+    def _static_antenna_position(self) -> Position:
+        configuration = self._config_object['STATIC ANTENNA POSITION']
+        return Position(
+            altitude=float(configuration['Altitude']),
+            azimuth=float(configuration['Azimuth'])
+        )
+
+    @cached_property
+    def _config_object(self) -> dict:
         config_object = ConfigParser()
         config_object.read(self._filepath)
-        return config_object['RESERVATION']
+        return config_object

--- a/satellite_determination/config_file.py
+++ b/satellite_determination/config_file.py
@@ -54,16 +54,20 @@ class ConfigFile:
 
     @cached_property
     def _observation_target(self) -> ObservationTarget:
-        observation_target_parameters = self._config_object['OBSERVATION TARGET']
-        return ObservationTarget(
-            declination=observation_target_parameters['Declination'],
-            right_ascension=observation_target_parameters['Right Ascension']
+        configuration = self._config_object['OBSERVATION TARGET'] \
+            if 'OBSERVATION TARGET' in self._config_object \
+            else None
+        return configuration and ObservationTarget(
+            declination=configuration['Declination'],
+            right_ascension=configuration['Right Ascension']
         )
 
     @cached_property
     def _static_antenna_position(self) -> Position:
-        configuration = self._config_object['STATIC ANTENNA POSITION']
-        return Position(
+        configuration = self._config_object['STATIC ANTENNA POSITION'] \
+            if 'STATIC ANTENNA POSITION' in self._config_object \
+            else None
+        return configuration and Position(
             altitude=float(configuration['Altitude']),
             azimuth=float(configuration['Azimuth'])
         )

--- a/satellite_determination/custom_dataclasses/configuration.py
+++ b/satellite_determination/custom_dataclasses/configuration.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from satellite_determination.custom_dataclasses.observation_target import ObservationTarget
+from satellite_determination.custom_dataclasses.position import Position
+from satellite_determination.custom_dataclasses.reservation import Reservation
+
+
+@dataclass
+class Configuration:
+    reservation: Reservation
+    observation_target: Optional[ObservationTarget] = None
+    static_antenna_position:  Optional[Position] = None

--- a/satellite_determination/custom_dataclasses/facility.py
+++ b/satellite_determination/custom_dataclasses/facility.py
@@ -16,7 +16,7 @@ class Facility:
     -elevation:         ground elevation of the telescope in meters. float. Defaults to 0
     -height:            height of the telescope. float. Defaults to 100
     -name:              name of the facility. String. Defaults to 'Unnamed Facility'
-Z    '''
+    '''
     coordinates: Coordinates
     antenna_positions: List[PositionTime] = field(default_factory=list)
     beamwidth: float = 3

--- a/satellite_determination/custom_dataclasses/facility.py
+++ b/satellite_determination/custom_dataclasses/facility.py
@@ -13,27 +13,16 @@ class Facility:
 
     -coordinates:       location of RA facility. Coordinates.
     -beamwidth:         beamwidth of the telescope. float. Defaults to 3
+    -elevation:         ground elevation of the telescope in meters. float. Defaults to 0
     -height:            height of the telescope. float. Defaults to 100
     -name:              name of the facility. String. Defaults to 'Unnamed Facility'
-    -elevation:         elevation (altitude) of the telescope in meters. float. Defaults to 0 to find all sats above the horizon
-    -right_ascension:   (optional) the right ascension of the observation target. String.
-    -declination:       (optional) the declination of the observation target. String.
-    -azimuth:           (optional) azimuth of the telescope. float.
-
-    If finding interference as an RA telescope tracks a target across the sky, the right ascension and declination of
-    the target is necessary but not the azimuth and elevation. The opposite is true for stationary observations.
-
-    '''
+Z    '''
     coordinates: Coordinates
     antenna_positions: List[PositionTime] = field(default_factory=list)
     beamwidth: float = 3
+    elevation: float = 0
     height: float = 100
     name: Optional[str] = 'Unnamed Facility'
-    elevation: float = 0
-    right_ascension: Optional[str] = None
-    declination: Optional[str] = None
-    azimuth: Optional[float] = None
-
 
     @property
     def half_beamwidth(self) -> float:

--- a/satellite_determination/custom_dataclasses/facility.py
+++ b/satellite_determination/custom_dataclasses/facility.py
@@ -18,7 +18,6 @@ class Facility:
     -name:              name of the facility. String. Defaults to 'Unnamed Facility'
     '''
     coordinates: Coordinates
-    antenna_positions: List[PositionTime] = field(default_factory=list)
     beamwidth: float = 3
     elevation: float = 0
     height: float = 100

--- a/satellite_determination/custom_dataclasses/observation_target.py
+++ b/satellite_determination/custom_dataclasses/observation_target.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class ObservationTarget:
+    declination: str
+    right_ascension: str

--- a/satellite_determination/custom_dataclasses/position.py
+++ b/satellite_determination/custom_dataclasses/position.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Position:
+    """
+    + altitude: degrees above the horizon
+    + azimuth: degrees east along the horizon from geographic north (so 0 degrees means north, 90 is east, 180
+        is south, and 270 is west).
+    """
+    altitude: float
+    azimuth: float

--- a/satellite_determination/custom_dataclasses/position_time.py
+++ b/satellite_determination/custom_dataclasses/position_time.py
@@ -1,15 +1,10 @@
 from dataclasses import dataclass
 from datetime import datetime
 
+from satellite_determination.custom_dataclasses.position import Position
+
 
 @dataclass
 class PositionTime:
-    """
-    + altitude: degrees above the horizon
-    + azimuth: degrees east along the horizon from geographic north (so 0 degrees means north, 90 is east, 180
-        is south, and 270 is west).
-    + time: a timestamp
-    """
-    altitude: float
-    azimuth: float
+    position: Position
     time: datetime

--- a/satellite_determination/custom_dataclasses/reservation.py
+++ b/satellite_determination/custom_dataclasses/reservation.py
@@ -1,6 +1,4 @@
 from dataclasses import dataclass, field
-from datetime import datetime
-from enum import Enum
 
 from satellite_determination.custom_dataclasses.facility import Facility
 from satellite_determination.custom_dataclasses.frequency_range.frequency_range import FrequencyRange
@@ -12,13 +10,6 @@ The Reservation class stores the Facility, as well as some additional reservatio
   + time:       TimeWindow that represents the start and end time of the ideal reservation.
   + frequency:  FrequencyRange of the requested observation. This is the frequency that the RA telescope wants to observe at.
 '''
-
-class ReservationJsonKey(Enum):
-    facility = 'facility'
-    time_start = 'time_start'
-    time_end = 'time_end'
-    frequency = 'frequency'
-    bandwidth = 'bandwidth'
 
 
 @dataclass

--- a/satellite_determination/event_finder/event_finder.py
+++ b/satellite_determination/event_finder/event_finder.py
@@ -8,16 +8,25 @@ from satellite_determination.custom_dataclasses.reservation import Reservation
 from satellite_determination.custom_dataclasses.satellite.satellite import Satellite
 from satellite_determination.event_finder.event_finder_rhodesmill.support.satellite_position_with_respect_to_facility_retriever.satellite_position_with_respect_to_facility_retriever import \
     SatellitePositionWithRespectToFacilityRetriever
-from satellite_determination.event_finder.event_finder_rhodesmill.support.satellite_position_with_respect_to_facility_retriever.satellite_position_with_respect_to_facility_retriever_rhodesmill import \
-    SatellitePositionWithRespectToFacilityRetrieverRhodesmill
 
 
 class EventFinder(ABC):
+    '''
+    The EventFinder is the module that determines if a satellite interferes with an RA observation. It has three functions:
+
+      + get_overhead_windows_slew():    determines if a satellite crosses the telescope's main beam as the telescope moves across the sky
+                                        by looking for intersections of azimuth and altitude and returning a list of OverheadWindows for
+                                        events where this occurs
+      + get_overhead_windows():         Determines the satellites visible above the horizon during the search window and returns a list of
+                                        OverheadWindows for each event. This can be used to find all satellite visible over the horizon or
+                                        to determine events for a stationary observation if an azimuth and altitude is provided
+
+    '''
     def __init__(self,
                  antenna_direction_path: List[PositionTime],
                  list_of_satellites: List[Satellite],
                  reservation: Reservation,
-                 satellite_position_with_respect_to_facility_retriever_class: Type[SatellitePositionWithRespectToFacilityRetriever] = SatellitePositionWithRespectToFacilityRetrieverRhodesmill,
+                 satellite_position_with_respect_to_facility_retriever_class: Type[SatellitePositionWithRespectToFacilityRetriever],
                  time_continuity_resolution: timedelta = timedelta(seconds=1)):
         self.antenna_direction_path = antenna_direction_path
         self.list_of_satellites = list_of_satellites

--- a/satellite_determination/event_finder/event_finder_rhodesmill/event_finder_rhodesmill.py
+++ b/satellite_determination/event_finder/event_finder_rhodesmill/event_finder_rhodesmill.py
@@ -1,14 +1,19 @@
 from dataclasses import replace
-from datetime import datetime
-from typing import Iterable, List
+from datetime import datetime, timedelta
+from typing import Iterable, List, Type
 
 from satellite_determination.custom_dataclasses.facility import Facility
 from satellite_determination.custom_dataclasses.overhead_window import OverheadWindow
 from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.position_time import PositionTime
+from satellite_determination.custom_dataclasses.reservation import Reservation
 from satellite_determination.custom_dataclasses.time_window import TimeWindow
 from satellite_determination.event_finder.event_finder_rhodesmill.support.pseudo_continuous_timestamps_calculator import \
     PseudoContinuousTimestampsCalculator
+from satellite_determination.event_finder.event_finder_rhodesmill.support.satellite_position_with_respect_to_facility_retriever.satellite_position_with_respect_to_facility_retriever import \
+    SatellitePositionWithRespectToFacilityRetriever
+from satellite_determination.event_finder.event_finder_rhodesmill.support.satellite_position_with_respect_to_facility_retriever.satellite_position_with_respect_to_facility_retriever_rhodesmill import \
+    SatellitePositionWithRespectToFacilityRetrieverRhodesmill
 from satellite_determination.event_finder.event_finder_rhodesmill.support.satellites_within_main_beam_filter import AntennaPosition, \
     SatellitesWithinMainBeamFilter
 from satellite_determination.event_finder.event_finder import EventFinder
@@ -17,17 +22,18 @@ from satellite_determination.utilities import convert_datetime_to_utc
 
 
 class EventFinderRhodesMill(EventFinder):
-    '''
-    The EventFinderRhodesMill is the module that determines if a satellite interferes with an RA observation. It has three functions:
+    def __init__(self,
+                 antenna_direction_path: List[PositionTime],
+                 list_of_satellites: List[Satellite],
+                 reservation: Reservation,
+                 satellite_position_with_respect_to_facility_retriever_class: Type[SatellitePositionWithRespectToFacilityRetriever] = SatellitePositionWithRespectToFacilityRetrieverRhodesmill,
+                 time_continuity_resolution: timedelta = timedelta(seconds=1)):
+        super().__init__(antenna_direction_path=antenna_direction_path,
+                         list_of_satellites=list_of_satellites,
+                         reservation=reservation,
+                         satellite_position_with_respect_to_facility_retriever_class=satellite_position_with_respect_to_facility_retriever_class,
+                         time_continuity_resolution=time_continuity_resolution)
 
-      + get_overhead_windows_slew():    determines if a satellite crosses the telescope's main beam as the telescope moves across the sky
-                                        by looking for intersections of azimuth and altitude and returning a list of OverheadWindows for
-                                        events where this occurs
-      + get_overhead_windows():         Determines the satellites visible above the horizon during the search window and returns a list of
-                                        OverheadWindows for each event. This can be used to find all satellite visible over the horizon or
-                                        to determine events for a stationary observation if an azimuth and altitude is provided
-
-    '''
     def get_satellites_above_horizon(self):
         facility_with_beam_width_that_sees_entire_sky = replace(self.reservation.facility, beamwidth=360)
         event_finder = EventFinderRhodesMill(list_of_satellites=self.list_of_satellites,

--- a/satellite_determination/event_finder/event_finder_rhodesmill/event_finder_rhodesmill.py
+++ b/satellite_determination/event_finder/event_finder_rhodesmill/event_finder_rhodesmill.py
@@ -4,6 +4,7 @@ from typing import Iterable, List
 
 from satellite_determination.custom_dataclasses.facility import Facility
 from satellite_determination.custom_dataclasses.overhead_window import OverheadWindow
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.position_time import PositionTime
 from satellite_determination.custom_dataclasses.time_window import TimeWindow
 from satellite_determination.event_finder.event_finder_rhodesmill.support.pseudo_continuous_timestamps_calculator import \
@@ -31,7 +32,8 @@ class EventFinderRhodesMill(EventFinder):
         facility_with_beam_width_that_sees_entire_sky = replace(self.reservation.facility, beamwidth=360)
         event_finder = EventFinderRhodesMill(list_of_satellites=self.list_of_satellites,
                                              reservation=replace(self.reservation, facility=facility_with_beam_width_that_sees_entire_sky),
-                                             antenna_direction_path=[PositionTime(altitude=90, azimuth=0, time=self.reservation.time.begin)])
+                                             antenna_direction_path=[PositionTime(position=Position(altitude=90, azimuth=0),
+                                                                                  time=self.reservation.time.begin)])
         return event_finder.get_satellites_crossing_main_beam()
 
     def get_satellites_crossing_main_beam(self) -> List[OverheadWindow]:

--- a/satellite_determination/event_finder/event_finder_rhodesmill/support/satellite_position_with_respect_to_facility_retriever/satellite_position_with_respect_to_facility_retriever_rhodesmill.py
+++ b/satellite_determination/event_finder/event_finder_rhodesmill/support/satellite_position_with_respect_to_facility_retriever/satellite_position_with_respect_to_facility_retriever_rhodesmill.py
@@ -2,6 +2,7 @@ from skyfield.api import load
 from skyfield.sgp4lib import EarthSatellite
 from skyfield.toposlib import wgs84
 
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.position_time import PositionTime
 from satellite_determination.event_finder.event_finder_rhodesmill.support.satellite_position_with_respect_to_facility_retriever.satellite_position_with_respect_to_facility_retriever import \
     SatellitePositionWithRespectToFacilityRetriever
@@ -23,8 +24,7 @@ class SatellitePositionWithRespectToFacilityRetrieverRhodesmill(SatellitePositio
         topocentric = satellite_rhodesmill_with_respect_to_facility.at(timestamps_rhodesmill)
         altitude, azimuth, _ = topocentric.altaz()
         return PositionTime(
-            altitude=altitude.degrees,
-            azimuth=azimuth.degrees,
+            position=Position(altitude=altitude.degrees, azimuth=azimuth.degrees),
             time=self._timestamp
         )
 

--- a/satellite_determination/event_finder/event_finder_rhodesmill/support/satellites_within_main_beam_filter.py
+++ b/satellite_determination/event_finder/event_finder_rhodesmill/support/satellites_within_main_beam_filter.py
@@ -46,10 +46,10 @@ class SatellitesWithinMainBeamFilter:
                 if satellite_position.time >= self._cutoff_time:
                     break
                 timestamp = convert_datetime_to_utc(satellite_position.time)
-                now_in_view = self._is_within_beam_width_altitude(satellite_altitude=satellite_position.altitude,
-                                                                  antenna_altitude=antenna_position.antenna_direction.altitude) \
-                              and self._is_within_beam_with_azimuth(satellite_azimuth=satellite_position.azimuth,
-                                                                    antenna_azimuth=antenna_position.antenna_direction.azimuth)
+                now_in_view = self._is_within_beam_width_altitude(satellite_altitude=satellite_position.position.altitude,
+                                                                  antenna_altitude=antenna_position.antenna_direction.position.altitude) \
+                              and self._is_within_beam_with_azimuth(satellite_azimuth=satellite_position.position.azimuth,
+                                                                    antenna_azimuth=antenna_position.antenna_direction.position.azimuth)
                 if now_in_view and not self._previously_in_view:
                     enter_events.append(timestamp)
                     self._previously_in_view = True

--- a/satellite_determination/main.py
+++ b/satellite_determination/main.py
@@ -6,11 +6,9 @@ from satellite_determination.custom_dataclasses.overhead_window import OverheadW
 from satellite_determination.custom_dataclasses.position_time import PositionTime
 from satellite_determination.custom_dataclasses.reservation import Reservation
 from satellite_determination.custom_dataclasses.satellite.satellite import Satellite
-from satellite_determination.custom_dataclasses.time_window import TimeWindow
 from satellite_determination.event_finder.event_finder import EventFinder
 from satellite_determination.event_finder.event_finder_rhodesmill.event_finder_rhodesmill import EventFinderRhodesMill
 from satellite_determination.frequency_filter.frequency_filter import FrequencyFilter
-from satellite_determination.path_finder.observation_path_finder import ObservationPathFinder
 
 
 @dataclass
@@ -45,5 +43,4 @@ class Main:
 
     @property
     def _antenna_direction_path(self) -> List[PositionTime]:
-        return self._reservation.facility.antenna_positions \
-            or ObservationPathFinder(facility=self._reservation.facility, time_window=self._reservation.time).calculate_path()
+        return self._reservation.facility.antenna_positions

--- a/satellite_determination/main.py
+++ b/satellite_determination/main.py
@@ -19,8 +19,10 @@ class MainResults:
 
 class Main:
     def __init__(self,
+                 antenna_direction_path: List[PositionTime],
                  reservation: Reservation,
                  satellites: List[Satellite]):
+        self._antenna_direction_path = antenna_direction_path
         self._reservation = reservation
         self._satellites = satellites
 
@@ -40,7 +42,3 @@ class Main:
     def _frequency_filtered_satellites(self) -> List[Satellite]:
         return FrequencyFilter(satellites=self._satellites,
                                observation_frequency=self._reservation.frequency).filter_frequencies()
-
-    @property
-    def _antenna_direction_path(self) -> List[PositionTime]:
-        return self._reservation.facility.antenna_positions

--- a/satellite_determination/path_finder/observation_path_finder.py
+++ b/satellite_determination/path_finder/observation_path_finder.py
@@ -32,7 +32,6 @@ class ObservationPathFinder:
         observation_path = []
         observing_location = EarthLocation(lat=str(self._facility.coordinates.latitude),
                                            lon=str(self._facility.coordinates.longitude),
-                                           elevation=self._facility.elevation,
                                            height=self._facility.height * units.m)
         target_coordinates = SkyCoord(self._observation_target.right_ascension, self._observation_target.declination)
         start_time = self._get_time_as_astropy_time(self._time_window.begin)

--- a/satellite_determination/path_finder/observation_path_finder.py
+++ b/satellite_determination/path_finder/observation_path_finder.py
@@ -8,6 +8,8 @@ from datetime import timedelta
 
 from satellite_determination.config_file import TIME_FORMAT
 from satellite_determination.custom_dataclasses.facility import Facility
+from satellite_determination.custom_dataclasses.observation_target import ObservationTarget
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.position_time import PositionTime
 import pytz
 
@@ -21,8 +23,9 @@ class ObservationPathFinder:
     target's right ascension and declination to determine this path.
     '''
 
-    def __init__(self, facility: Facility, time_window: TimeWindow) -> List[PositionTime]:
+    def __init__(self, facility: Facility, observation_target: ObservationTarget, time_window: TimeWindow) -> List[PositionTime]:
         self._facility = facility
+        self._observation_target = observation_target
         self._time_window = time_window
 
     def calculate_path(self) -> List[PositionTime]:
@@ -30,7 +33,7 @@ class ObservationPathFinder:
         observing_location = EarthLocation(lat=str(self._facility.coordinates.latitude),
                                            lon=str(self._facility.coordinates.longitude),
                                            height=self._facility.height * units.m)
-        target_coordinates = SkyCoord(self._facility.right_ascension, self._facility.declination)
+        target_coordinates = SkyCoord(self._observation_target.right_ascension, self._observation_target.declination)
         start_time = self._get_time_as_astropy_time(self._time_window.begin)
         end_time = self._get_time_as_astropy_time(self._time_window.end)
         while start_time <= end_time:
@@ -38,8 +41,7 @@ class ObservationPathFinder:
             altitude_azimuth = AltAz(location=observing_location, obstime=observing_time)
             point_coord = target_coordinates.transform_to(altitude_azimuth)
             point = PositionTime(
-                altitude=point_coord.alt.degree,
-                azimuth=point_coord.az.degree,
+                position=Position(altitude=point_coord.alt.degree, azimuth=point_coord.az.degree),
                 time=start_time.datetime.replace(tzinfo=pytz.UTC)
             )
             observation_path.append(point)

--- a/satellite_determination/path_finder/observation_path_finder.py
+++ b/satellite_determination/path_finder/observation_path_finder.py
@@ -32,6 +32,7 @@ class ObservationPathFinder:
         observation_path = []
         observing_location = EarthLocation(lat=str(self._facility.coordinates.latitude),
                                            lon=str(self._facility.coordinates.longitude),
+                                           elevation=self._facility.elevation,
                                            height=self._facility.height * units.m)
         target_coordinates = SkyCoord(self._observation_target.right_ascension, self._observation_target.declination)
         start_time = self._get_time_as_astropy_time(self._time_window.begin)

--- a/sopp.py
+++ b/sopp.py
@@ -6,6 +6,7 @@ from satellite_determination.custom_dataclasses.frequency_range.support.get_freq
     GetFrequencyDataFromCsv
 from satellite_determination.custom_dataclasses.satellite.satellite import Satellite
 from satellite_determination.main import Main
+from satellite_determination.path_finder.observation_path_finder import ObservationPathFinder
 from satellite_determination.utilities import get_frequencies_filepath, get_satellites_filepath
 from satellite_determination.graph_generator.graph_generator import GraphGenerator
 
@@ -18,8 +19,7 @@ def main():
     print('----------------------------------------------------------------------')
     print('Loading reservation parameters from config file...\n')  # make flag to specify config file, default .config
     config_file = ConfigFile()
-    reservation = config_file.reservation
-    search_window = config_file.search_window
+    reservation = config_file.configuration.reservation
 
     print('Finding satellite interference events for:\n')
     print('Facility: ', reservation.facility.name, ' at ', reservation.facility.coordinates)
@@ -34,6 +34,9 @@ def main():
     frequency_list = GetFrequencyDataFromCsv(filepath=frequency_file).get()
     satellite_list_with_frequencies = [replace(satellite, frequency=frequency_list.get(satellite.tle_information.satellite_number, []))
                                        for satellite in satellite_list]
+
+    reservation.facility.antenna_positions = reservation.facility.antenna_positions \
+        or ObservationPathFinder(facility=reservation.facility, time_window=reservation.time).calculate_path()
 
     results = Main(reservation=reservation, satellites=satellite_list_with_frequencies).run()
 

--- a/sopp.py
+++ b/sopp.py
@@ -35,7 +35,7 @@ def main():
     satellite_list_with_frequencies = [replace(satellite, frequency=frequency_list.get(satellite.tle_information.satellite_number, []))
                                        for satellite in satellite_list]
 
-    reservation.facility.antenna_positions = reservation.facility.antenna_positions \
+    reservation.facility.antenna_positions = [config_file.configuration.static_antenna_position] \
         or ObservationPathFinder(facility=reservation.facility, time_window=reservation.time).calculate_path()
 
     results = Main(reservation=reservation, satellites=satellite_list_with_frequencies).run()

--- a/tests/config_file/arbitrary_config_file_2.config
+++ b/tests/config_file/arbitrary_config_file_2.config
@@ -1,13 +1,17 @@
 [RESERVATION]
 Latitude=40.8178049
 Longitude=-121.4695413
-RightAscension=4h42m
-Declination=-38d6m50.8s
 Beamwidth=3
 Name=ARBITRARY_2
 StartTimeUTC=2023-03-30T10:00:00.000000
 EndTimeUTC=2023-03-30T11:00:00.000000
 Frequency=135
 Bandwidth=10
-SearchWindowStart=2023-03-30T11:00:00.000000
-SearchWindowEnd=2023-03-30T13:00:00.000000
+
+[OBSERVATION TARGET]
+Declination=-38d6m50.8s
+Right Ascension=4h42m
+
+[STATIC ANTENNA POSITION]
+Altitude=0.2
+Azimuth=0.3

--- a/tests/config_file/arbitrary_config_file_no_observation_target.config
+++ b/tests/config_file/arbitrary_config_file_no_observation_target.config
@@ -8,10 +8,6 @@ EndTimeUTC=2023-03-30T11:00:00.000000
 Frequency=135
 Bandwidth=10
 
-[OBSERVATION TARGET]
-Declination=-38d6m50.8s
-Right Ascension=4h42m
-
 [STATIC ANTENNA POSITION]
 Altitude=0.2
 Azimuth=0.3

--- a/tests/config_file/arbitrary_config_file_no_static_antenna_position.config
+++ b/tests/config_file/arbitrary_config_file_no_static_antenna_position.config
@@ -11,7 +11,3 @@ Bandwidth=10
 [OBSERVATION TARGET]
 Declination=-38d6m50.8s
 Right Ascension=4h42m
-
-[STATIC ANTENNA POSITION]
-Altitude=0.2
-Azimuth=0.3

--- a/tests/config_file/arbitrary_config_file_partial_observation_target.config
+++ b/tests/config_file/arbitrary_config_file_partial_observation_target.config
@@ -10,7 +10,6 @@ Bandwidth=10
 
 [OBSERVATION TARGET]
 Declination=-38d6m50.8s
-Right Ascension=4h42m
 
 [STATIC ANTENNA POSITION]
 Altitude=0.2

--- a/tests/config_file/arbitrary_config_file_partial_static_antenna_position.config
+++ b/tests/config_file/arbitrary_config_file_partial_static_antenna_position.config
@@ -14,4 +14,3 @@ Right Ascension=4h42m
 
 [STATIC ANTENNA POSITION]
 Altitude=0.2
-Azimuth=0.3

--- a/tests/config_file/test_config_file_default_argument.py
+++ b/tests/config_file/test_config_file_default_argument.py
@@ -7,9 +7,12 @@ import pytest
 import pytz
 
 from satellite_determination.config_file import ConfigFile
+from satellite_determination.custom_dataclasses.configuration import Configuration
 from satellite_determination.custom_dataclasses.coordinates import Coordinates
 from satellite_determination.custom_dataclasses.facility import Facility
 from satellite_determination.custom_dataclasses.frequency_range.frequency_range import FrequencyRange
+from satellite_determination.custom_dataclasses.observation_target import ObservationTarget
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.reservation import Reservation
 from satellite_determination.custom_dataclasses.time_window import TimeWindow
 from satellite_determination.utilities import get_default_config_file_filepath, get_script_directory
@@ -39,23 +42,21 @@ class TestConfigFileDefaultArgument:
 
         default_filepath.unlink(missing_ok=True)
 
-    def test_reads_inputs_of_provided_config_file_correctly(self, config_file):
-        assert config_file.reservation == Reservation(
-            facility=Facility(
-                right_ascension='4h42m',
-                coordinates=Coordinates(latitude=40.8178049,
-                                        longitude=-121.4695413),
-                name='ARBITRARY_2',
-                declination='-38d6m50.8s',
+    def test_reads_inputs_of_provided_config_file_correctly(self, config_file: ConfigFile):
+        assert config_file.configuration == Configuration(
+            reservation=Reservation(
+                facility=Facility(
+                    coordinates=Coordinates(latitude=40.8178049,
+                                            longitude=-121.4695413),
+                    name='ARBITRARY_2',
+                ),
+                time=TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=10, tzinfo=pytz.UTC),
+                                end=datetime(year=2023, month=3, day=30, hour=11, tzinfo=pytz.UTC)),
+                frequency=FrequencyRange(
+                    frequency=135,
+                    bandwidth=10
+                )
             ),
-            time=TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=10, tzinfo=pytz.UTC),
-                            end=datetime(year=2023, month=3, day=30, hour=11, tzinfo=pytz.UTC)),
-            frequency=FrequencyRange(
-                frequency=135,
-                bandwidth=10
-            )
+            observation_target=ObservationTarget(declination='-38d6m50.8s', right_ascension='4h42m'),
+            static_antenna_position=Position(altitude=.2, azimuth=.3)
         )
-
-    def test_reads_search_window_inputs_correctly(self, config_file):
-        assert config_file.search_window == TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=11, tzinfo=pytz.UTC),
-                                                       end=datetime(year=2023, month=3, day=30, hour=13, tzinfo=pytz.UTC))

--- a/tests/config_file/test_config_file_provided_argument.py
+++ b/tests/config_file/test_config_file_provided_argument.py
@@ -19,7 +19,7 @@ class TestConfigFileProvidedArgument:
         return ConfigFile(filepath=Path(get_script_directory(__file__), 'arbitrary_config_file.config'))
 
     def test_reads_inputs_of_provided_config_file_correctly(self, config_file):
-        assert config_file.reservation == Reservation(
+        assert config_file._reservation == Reservation(
             facility=Facility(
                 right_ascension='4h42m',
                 coordinates=Coordinates(latitude=40.8178049,
@@ -35,6 +35,6 @@ class TestConfigFileProvidedArgument:
             )
         )
 
-    def test_reads_search_window_inputs_correctly(self, config_file):
-        assert config_file.search_window == TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=11, tzinfo=pytz.UTC),
-                                                       end=datetime(year=2023, month=3, day=30, hour=12, tzinfo=pytz.UTC))
+    def test_optional_observation_target(self, config_file):
+        assert False
+

--- a/tests/config_file/test_config_file_provided_argument.py
+++ b/tests/config_file/test_config_file_provided_argument.py
@@ -5,36 +5,60 @@ import pytest
 import pytz
 
 from satellite_determination.config_file import ConfigFile
+from satellite_determination.custom_dataclasses.configuration import Configuration
 from satellite_determination.custom_dataclasses.coordinates import Coordinates
 from satellite_determination.custom_dataclasses.facility import Facility
 from satellite_determination.custom_dataclasses.frequency_range.frequency_range import FrequencyRange
+from satellite_determination.custom_dataclasses.observation_target import ObservationTarget
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.reservation import Reservation
 from satellite_determination.custom_dataclasses.time_window import TimeWindow
 from satellite_determination.utilities import get_script_directory
 
 
 class TestConfigFileProvidedArgument:
-    @pytest.fixture
-    def config_file(self) -> ConfigFile:
-        return ConfigFile(filepath=Path(get_script_directory(__file__), 'arbitrary_config_file.config'))
-
-    def test_reads_inputs_of_provided_config_file_correctly(self, config_file):
-        assert config_file._reservation == Reservation(
-            facility=Facility(
-                right_ascension='4h42m',
-                coordinates=Coordinates(latitude=40.8178049,
-                                        longitude=-121.4695413),
-                name='ARBITRARY_1',
-                declination='-38d6m50.8s',
+    def test_reads_inputs_of_provided_config_file_correctly(self):
+        config_file = self._get_config_file_object('arbitrary_config_file.config')
+        assert config_file.configuration == Configuration(
+            reservation=Reservation(
+                facility=Facility(
+                    coordinates=Coordinates(latitude=40.8178049,
+                                            longitude=-121.4695413),
+                    name='ARBITRARY_1',
+                ),
+                time=TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=10, tzinfo=pytz.UTC),
+                                end=datetime(year=2023, month=3, day=30, hour=11, tzinfo=pytz.UTC)),
+                frequency=FrequencyRange(
+                    frequency=135,
+                    bandwidth=10
+                )
             ),
-            time=TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=10, tzinfo=pytz.UTC),
-                            end=datetime(year=2023, month=3, day=30, hour=11, tzinfo=pytz.UTC)),
-            frequency=FrequencyRange(
-                frequency=135,
-                bandwidth=10
-            )
+            observation_target=ObservationTarget(declination='-38d6m50.8s', right_ascension='4h42m'),
+            static_antenna_position=Position(altitude=.2, azimuth=.3)
         )
 
-    def test_optional_observation_target(self, config_file):
-        assert False
+    def test_observation_target_is_optional(self):
+        config_file = self._get_config_file_object('arbitrary_config_file_no_observation_target.config')
+        assert config_file.configuration.observation_target is None
+        assert config_file.configuration.reservation is not None
+        assert config_file.configuration.static_antenna_position is not None
 
+    def test_error_is_returned_if_partial_observation_target(self):
+        config_file = self._get_config_file_object('arbitrary_config_file_partial_observation_target.config')
+        with pytest.raises(KeyError):
+            _ = config_file.configuration
+
+    def test_static_antenna_position_is_optional(self):
+        config_file = self._get_config_file_object('arbitrary_config_file_no_static_antenna_position.config')
+        assert config_file.configuration.static_antenna_position is None
+        assert config_file.configuration.observation_target is not None
+        assert config_file.configuration.reservation is not None
+
+    def test_error_is_returned_if_partial_static_antenna_position(self):
+        config_file = self._get_config_file_object('arbitrary_config_file_partial_static_antenna_position.config')
+        with pytest.raises(KeyError):
+            _ = config_file.configuration
+
+    @staticmethod
+    def _get_config_file_object(config_filename: str) -> ConfigFile:
+        return ConfigFile(filepath=Path(get_script_directory(__file__), config_filename))

--- a/tests/event_finder/event_finder_rhodesmill/definitions.py
+++ b/tests/event_finder/event_finder_rhodesmill/definitions.py
@@ -4,8 +4,9 @@ import pytz
 
 from satellite_determination.custom_dataclasses.coordinates import Coordinates
 from satellite_determination.custom_dataclasses.facility import Facility
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.position_time import PositionTime
 
 ARBITRARY_FACILITY = Facility(coordinates=Coordinates(latitude=0, longitude=0))
 
-ARBITRARY_ANTENNA_POSITION = PositionTime(altitude=100, azimuth=100, time=datetime.now(tz=pytz.UTC))
+ARBITRARY_ANTENNA_POSITION = PositionTime(position=Position(altitude=100, azimuth=100), time=datetime.now(tz=pytz.UTC))

--- a/tests/event_finder/event_finder_rhodesmill/support/test_satellite_position_with_respect_to_facility_retriever_rhodesmill.py
+++ b/tests/event_finder/event_finder_rhodesmill/support/test_satellite_position_with_respect_to_facility_retriever_rhodesmill.py
@@ -19,13 +19,13 @@ class TestSatellitePositionWithRespectToFacilityRetrieverRhodesmill:
         timestamp = datetime(year=2023, month=6, day=7, tzinfo=pytz.UTC)
         facility = Facility(Coordinates(latitude=0, longitude=0))
         position = self._get_satellite_position(facility=facility, timestamp=timestamp)
-        assert position.altitude < 0
+        assert position.position.altitude < 0
 
     def test_azimuth_can_be_greater_than_180(self):
         timestamp = datetime(year=2023, month=6, day=7, tzinfo=pytz.UTC)
         facility = Facility(Coordinates(latitude=0, longitude=0))
         position = self._get_satellite_position(facility=facility, timestamp=timestamp)
-        assert position.azimuth > 180
+        assert position.position.azimuth > 180
 
     def test_altitude_decreases_as_elevation_increases(self):
         timestamp = datetime(year=2023, month=6, day=7, tzinfo=pytz.UTC)
@@ -35,7 +35,7 @@ class TestSatellitePositionWithRespectToFacilityRetrieverRhodesmill:
                                                            timestamp=timestamp)
         position_with_higher_elevation = self._get_satellite_position(facility=same_facility_with_higher_elevation,
                                                                       timestamp=timestamp)
-        assert position_with_higher_elevation.altitude < position_at_horizon.altitude
+        assert position_with_higher_elevation.position.altitude < position_at_horizon.position.altitude
 
     def _get_satellite_position(self, facility: Facility, timestamp: datetime) -> PositionTime:
         retriever = SatellitePositionWithRespectToFacilityRetrieverRhodesmill(satellite=self._arbitrary_satellite,

--- a/tests/event_finder/event_finder_rhodesmill/test_event_finder_reservation_start_time.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_event_finder_reservation_start_time.py
@@ -5,6 +5,7 @@ import pytz
 from satellite_determination.custom_dataclasses.coordinates import Coordinates
 from satellite_determination.custom_dataclasses.facility import Facility
 from satellite_determination.custom_dataclasses.overhead_window import OverheadWindow
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.position_time import PositionTime
 from satellite_determination.custom_dataclasses.reservation import Reservation
 from satellite_determination.custom_dataclasses.satellite.satellite import Satellite
@@ -25,8 +26,8 @@ class TestEventFinderReservationStartTime:
                                             time=arbitrary_time_window)
         event_finder = EventFinderRhodesMill(list_of_satellites=[arbitrary_satellite],
                                              reservation=arbitrary_reservation,
-                                             antenna_direction_path=[PositionTime(altitude=ARBITRARY_SATELLITE_ALTITUDE,
-                                                                                  azimuth=ARBITRARY_SATELLITE_AZIMUTH,
+                                             antenna_direction_path=[PositionTime(position=Position(altitude=ARBITRARY_SATELLITE_ALTITUDE,
+                                                                                                    azimuth=ARBITRARY_SATELLITE_AZIMUTH),
                                                                                   time=arbitrary_datetime - timedelta(seconds=1))],
                                              satellite_position_with_respect_to_facility_retriever_class=SatellitePositionWithRespectToFacilityRetrieverStub)
         windows = event_finder.get_satellites_crossing_main_beam()
@@ -42,11 +43,11 @@ class TestEventFinderReservationStartTime:
         altitude_inside_beam_width = ARBITRARY_SATELLITE_ALTITUDE
         altitude_outside_beam_width = ARBITRARY_SATELLITE_ALTITUDE + arbitrary_reservation.facility.half_beamwidth + SMALL_EPSILON
         arbitrary_time_before_reservation_starts = arbitrary_datetime - timedelta(seconds=1)
-        antenna_position_that_ends_before_reservation_begins = PositionTime(altitude=altitude_inside_beam_width,
-                                                                            azimuth=ARBITRARY_SATELLITE_AZIMUTH,
+        antenna_position_that_ends_before_reservation_begins = PositionTime(position=Position(altitude=altitude_inside_beam_width,
+                                                                                              azimuth=ARBITRARY_SATELLITE_AZIMUTH),
                                                                             time=arbitrary_time_before_reservation_starts - timedelta(seconds=1))
-        antenna_position_that_has_no_satellites_in_beam = PositionTime(altitude=altitude_outside_beam_width,
-                                                                       azimuth=ARBITRARY_SATELLITE_AZIMUTH,
+        antenna_position_that_has_no_satellites_in_beam = PositionTime(position=Position(altitude=altitude_outside_beam_width,
+                                                                                         azimuth=ARBITRARY_SATELLITE_AZIMUTH),
                                                                        time=arbitrary_time_before_reservation_starts)
         event_finder = EventFinderRhodesMill(list_of_satellites=[arbitrary_satellite],
                                              reservation=arbitrary_reservation,

--- a/tests/event_finder/event_finder_rhodesmill/test_event_finder_rhodesmill.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_event_finder_rhodesmill.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from satellite_determination.custom_dataclasses.coordinates import Coordinates
 from satellite_determination.custom_dataclasses.facility import Facility
 from satellite_determination.custom_dataclasses.overhead_window import OverheadWindow
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.position_time import PositionTime
 from satellite_determination.custom_dataclasses.reservation import Reservation
 from satellite_determination.custom_dataclasses.satellite.satellite import Satellite
@@ -20,8 +21,8 @@ ARBITRARY_SATELLITE_AZIMUTH = 0
 class SatellitePositionWithRespectToFacilityRetrieverStub(SatellitePositionWithRespectToFacilityRetriever):
     def run(self) -> PositionTime:
         return PositionTime(
-            altitude=ARBITRARY_SATELLITE_ALTITUDE,
-            azimuth=ARBITRARY_SATELLITE_AZIMUTH,
+            position=Position(altitude=ARBITRARY_SATELLITE_ALTITUDE,
+                              azimuth=ARBITRARY_SATELLITE_AZIMUTH),
             time=self._timestamp
         )
 
@@ -36,8 +37,8 @@ class TestEventFinderRhodesmill:
                                             time=arbitrary_time_window)
         event_finder = EventFinderRhodesMill(list_of_satellites=[arbitrary_satellite],
                                              reservation=arbitrary_reservation,
-                                             antenna_direction_path=[PositionTime(altitude=ARBITRARY_SATELLITE_ALTITUDE,
-                                                                                  azimuth=ARBITRARY_SATELLITE_AZIMUTH,
+                                             antenna_direction_path=[PositionTime(position=Position(altitude=ARBITRARY_SATELLITE_ALTITUDE,
+                                                                                                    azimuth=ARBITRARY_SATELLITE_AZIMUTH),
                                                                                   time=arbitrary_datetime)],
                                              satellite_position_with_respect_to_facility_retriever_class=SatellitePositionWithRespectToFacilityRetrieverStub)
         windows = event_finder.get_satellites_crossing_main_beam()
@@ -52,8 +53,8 @@ class TestEventFinderRhodesmill:
                                             time=arbitrary_time_window)
         event_finder = EventFinderRhodesMill(list_of_satellites=arbitrary_satellites,
                                              reservation=arbitrary_reservation,
-                                             antenna_direction_path=[PositionTime(altitude=ARBITRARY_SATELLITE_ALTITUDE,
-                                                                                  azimuth=ARBITRARY_SATELLITE_AZIMUTH,
+                                             antenna_direction_path=[PositionTime(position=Position(altitude=ARBITRARY_SATELLITE_ALTITUDE,
+                                                                                                    azimuth=ARBITRARY_SATELLITE_AZIMUTH),
                                                                                   time=arbitrary_datetime)],
                                              satellite_position_with_respect_to_facility_retriever_class=SatellitePositionWithRespectToFacilityRetrieverStub)
         windows = event_finder.get_satellites_crossing_main_beam()
@@ -71,14 +72,14 @@ class TestEventFinderRhodesmill:
         event_finder = EventFinderRhodesMill(list_of_satellites=[arbitrary_satellite],
                                              reservation=arbitrary_reservation,
                                              antenna_direction_path=[
-                                                 PositionTime(altitude=ARBITRARY_SATELLITE_ALTITUDE,
-                                                              azimuth=ARBITRARY_SATELLITE_AZIMUTH,
+                                                 PositionTime(position=Position(altitude=ARBITRARY_SATELLITE_ALTITUDE,
+                                                                                azimuth=ARBITRARY_SATELLITE_AZIMUTH),
                                                               time=arbitrary_datetime),
-                                                 PositionTime(altitude=altitude_outside_beamwidth,
-                                                              azimuth=ARBITRARY_SATELLITE_AZIMUTH,
+                                                 PositionTime(position=Position(altitude=altitude_outside_beamwidth,
+                                                                                azimuth=ARBITRARY_SATELLITE_AZIMUTH),
                                                               time=arbitrary_datetime + timedelta(seconds=1)),
-                                                 PositionTime(altitude=ARBITRARY_SATELLITE_ALTITUDE,
-                                                              azimuth=ARBITRARY_SATELLITE_AZIMUTH,
+                                                 PositionTime(position=Position(altitude=ARBITRARY_SATELLITE_ALTITUDE,
+                                                                                azimuth=ARBITRARY_SATELLITE_AZIMUTH),
                                                               time=arbitrary_datetime + timedelta(seconds=2))
                                              ],
                                              satellite_position_with_respect_to_facility_retriever_class=SatellitePositionWithRespectToFacilityRetrieverStub)

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter.py
@@ -1,8 +1,10 @@
 from dataclasses import replace
 from datetime import datetime, timedelta
+from typing import Optional
 
 import pytz
 
+from satellite_determination.custom_dataclasses.position_time import PositionTime
 from satellite_determination.custom_dataclasses.time_window import TimeWindow
 from satellite_determination.event_finder.event_finder_rhodesmill.support.satellites_within_main_beam_filter import SatellitesWithinMainBeamFilter, \
     AntennaPosition
@@ -33,8 +35,8 @@ class TestSatellitesWithinMainBeam:
 
     def test_one_satellite_position_outside_beamwidth_azimuth(self):
         satellite_positions = [
-            replace(ARBITRARY_ANTENNA_POSITION,
-                    azimuth=ARBITRARY_ANTENNA_POSITION.azimuth - self._value_slightly_larger_than_half_beamwidth)
+            self._replace_antenna_position(antenna_position=ARBITRARY_ANTENNA_POSITION,
+                                           azimuth=ARBITRARY_ANTENNA_POSITION.position.azimuth - self._value_slightly_larger_than_half_beamwidth)
         ]
         slew = SatellitesWithinMainBeamFilter(facility=ARBITRARY_FACILITY,
                                               antenna_positions=[AntennaPosition(satellite_positions=satellite_positions,
@@ -44,11 +46,11 @@ class TestSatellitesWithinMainBeam:
         assert windows == []
 
     def test_one_satellite_with_multiple_sequential_positions_in_view(self):
-        out_of_altitude = ARBITRARY_ANTENNA_POSITION.altitude - self._value_slightly_larger_than_half_beamwidth
+        out_of_altitude = ARBITRARY_ANTENNA_POSITION.position.altitude - self._value_slightly_larger_than_half_beamwidth
         satellite_positions = [
-            replace(ARBITRARY_ANTENNA_POSITION,
-                    altitude=out_of_altitude if i == 2 else ARBITRARY_ANTENNA_POSITION.altitude,
-                    time=ARBITRARY_ANTENNA_POSITION.time + timedelta(minutes=i))
+            self._replace_antenna_position(antenna_position=ARBITRARY_ANTENNA_POSITION,
+                                           altitude=out_of_altitude if i == 2 else ARBITRARY_ANTENNA_POSITION.position.altitude,
+                                           time=ARBITRARY_ANTENNA_POSITION.time + timedelta(minutes=i))
             for i in range(3)
         ]
         cutoff_time = ARBITRARY_ANTENNA_POSITION.time + timedelta(minutes=len(satellite_positions))
@@ -63,11 +65,11 @@ class TestSatellitesWithinMainBeam:
         ]
 
     def test_one_satellite_with_multiple_sequential_positions_out_of_view(self):
-        out_of_altitude = ARBITRARY_ANTENNA_POSITION.altitude - self._value_slightly_larger_than_half_beamwidth
+        out_of_altitude = ARBITRARY_ANTENNA_POSITION.position.altitude - self._value_slightly_larger_than_half_beamwidth
         satellite_positions = [
-            replace(ARBITRARY_ANTENNA_POSITION,
-                    altitude=out_of_altitude if 0 < i < 3 else ARBITRARY_ANTENNA_POSITION.altitude,
-                    time=ARBITRARY_ANTENNA_POSITION.time + timedelta(minutes=i))
+            self._replace_antenna_position(antenna_position=ARBITRARY_ANTENNA_POSITION,
+                                           altitude=out_of_altitude if 0 < i < 3 else ARBITRARY_ANTENNA_POSITION.position.altitude,
+                                           time=ARBITRARY_ANTENNA_POSITION.time + timedelta(minutes=i))
             for i in range(4)
         ]
         cutoff_time = ARBITRARY_ANTENNA_POSITION.time + timedelta(minutes=len(satellite_positions))
@@ -87,9 +89,11 @@ class TestSatellitesWithinMainBeam:
         return ARBITRARY_FACILITY.half_beamwidth + SMALL_EPSILON
 
     def test_one_satellite_below_horizon_but_within_beamwidth(self):
-        antenna_position_at_horizon = replace(ARBITRARY_ANTENNA_POSITION, altitude=0)
+        antenna_position_at_horizon = self._replace_antenna_position(antenna_position=ARBITRARY_ANTENNA_POSITION,
+                                                                     altitude=0)
         satellite_positions = [
-            replace(antenna_position_at_horizon, altitude=-SMALL_EPSILON)
+            self._replace_antenna_position(antenna_position=antenna_position_at_horizon,
+                                           altitude=-SMALL_EPSILON)
         ]
         slew = SatellitesWithinMainBeamFilter(facility=ARBITRARY_FACILITY,
                                               antenna_positions=[
@@ -100,10 +104,12 @@ class TestSatellitesWithinMainBeam:
         assert windows == []
 
     def test_no_satellites_past_cutoff_time(self):
-        azimuth_outside_main_beam = ARBITRARY_ANTENNA_POSITION.azimuth + ARBITRARY_FACILITY.half_beamwidth + SMALL_EPSILON
-        satellite_position_outside_main_beam = replace(ARBITRARY_ANTENNA_POSITION, azimuth=azimuth_outside_main_beam)
-        satellite_position_inside_main_beam_but_past_cutoff_time = replace(ARBITRARY_ANTENNA_POSITION,
-                                                                           time=ARBITRARY_ANTENNA_POSITION.time + timedelta(seconds=2))
+        azimuth_outside_main_beam = ARBITRARY_ANTENNA_POSITION.position.azimuth + ARBITRARY_FACILITY.half_beamwidth + SMALL_EPSILON
+        satellite_position_outside_main_beam = self._replace_antenna_position(antenna_position=ARBITRARY_ANTENNA_POSITION,
+                                                                              azimuth=azimuth_outside_main_beam)
+        satellite_position_inside_main_beam_but_past_cutoff_time = self._replace_antenna_position(
+            antenna_position=ARBITRARY_ANTENNA_POSITION,
+            time=ARBITRARY_ANTENNA_POSITION.time + timedelta(seconds=2))
         satellite_positions = [
             satellite_position_outside_main_beam,
             satellite_position_inside_main_beam_but_past_cutoff_time
@@ -119,8 +125,8 @@ class TestSatellitesWithinMainBeam:
 
     def test_satellite_reenters_horizon(self):
         facility_with_beam_width_that_sees_entire_sky = replace(ARBITRARY_FACILITY, beamwidth=360)
-        satellite_positions_above_horizon = replace(ARBITRARY_ANTENNA_POSITION, altitude=1)
-        satellite_positions_below_horizon = replace(ARBITRARY_ANTENNA_POSITION, altitude=-1)
+        satellite_positions_above_horizon = self._replace_antenna_position(ARBITRARY_ANTENNA_POSITION, altitude=1)
+        satellite_positions_below_horizon = self._replace_antenna_position(ARBITRARY_ANTENNA_POSITION, altitude=-1)
         satellite_positions_without_time = [satellite_positions_above_horizon,
                                             satellite_positions_below_horizon,
                                             satellite_positions_above_horizon]
@@ -141,3 +147,14 @@ class TestSatellitesWithinMainBeam:
     @property
     def _arbitrary_cutoff_time(self) -> datetime:
         return datetime.now(tz=pytz.UTC)
+
+    @staticmethod
+    def _replace_antenna_position(antenna_position: PositionTime,
+                                  altitude: Optional[float] = None,
+                                  azimuth: Optional[float] = None,
+                                  time: Optional[datetime] = None) -> PositionTime:
+        return replace(antenna_position,
+                       position=replace(antenna_position.position,
+                                        altitude=antenna_position.position.altitude if altitude is None else altitude,
+                                        azimuth=antenna_position.position.azimuth if azimuth is None else azimuth),
+                       time=antenna_position.time if time is None else time)

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_altitude.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_altitude.py
@@ -14,17 +14,17 @@ from tests.event_finder.event_finder_rhodesmill.definitions import ARBITRARY_ANT
 
 class TestSatellitesWithinMainBeamAltitude:
     def test_one_satellite_position_below_beamwidth_altitude(self):
-        self._run_test(altitude=ARBITRARY_ANTENNA_POSITION.altitude - self._value_slightly_larger_than_half_beamwidth,
+        self._run_test(altitude=ARBITRARY_ANTENNA_POSITION.position.altitude - self._value_slightly_larger_than_half_beamwidth,
                        expected_windows=[])
 
     def test_one_satellite_position_above_beamwidth_altitude(self):
-        self._run_test(altitude=ARBITRARY_ANTENNA_POSITION.altitude + self._value_slightly_larger_than_half_beamwidth,
+        self._run_test(altitude=ARBITRARY_ANTENNA_POSITION.position.altitude + self._value_slightly_larger_than_half_beamwidth,
                        expected_windows=[TimeWindow(begin=ARBITRARY_ANTENNA_POSITION.time, end=self._arbitrary_cutoff_time)])
 
     def _run_test(self, altitude: float, expected_windows: List[TimeWindow]) -> None:
         satellite_positions = [
             replace(ARBITRARY_ANTENNA_POSITION,
-                    altitude=altitude)
+                    position=replace(ARBITRARY_ANTENNA_POSITION.position, altitude=altitude))
         ]
         slew = SatellitesWithinMainBeamFilter(facility=ARBITRARY_FACILITY,
                                               antenna_positions=[

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_unsorted_antenna_positions.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_unsorted_antenna_positions.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from typing import List
 
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.position_time import PositionTime
 from satellite_determination.custom_dataclasses.time_window import TimeWindow
 from satellite_determination.event_finder.event_finder_rhodesmill.support.satellites_within_main_beam_filter import AntennaPosition, \
@@ -31,6 +32,6 @@ class TestSatellitesWithinMainBeamMultipleAntennas:
 
     @property
     def _antenna_positions_sorted_by_time_ascending(self) -> List[PositionTime]:
-        arbitrary_antenna_position2 = PositionTime(altitude=200, azimuth=200,
+        arbitrary_antenna_position2 = PositionTime(position=Position(altitude=200, azimuth=200),
                                                    time=ARBITRARY_ANTENNA_POSITION.time + timedelta(minutes=1))
         return [ARBITRARY_ANTENNA_POSITION, arbitrary_antenna_position2]

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_unsorted_satellite_positions.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_unsorted_satellite_positions.py
@@ -36,10 +36,11 @@ class TestSatellitesWithinMainBeamOneAntennaPositionMultipleSatellitePositions:
     @cached_property
     def _satellite_positions_by_time_ascending(self) -> List[PositionTime]:
         value_slightly_larger_than_half_beam_width = ARBITRARY_FACILITY.half_beamwidth + SMALL_EPSILON
-        out_of_altitude = ARBITRARY_ANTENNA_POSITION.altitude - value_slightly_larger_than_half_beam_width
+        out_of_altitude = ARBITRARY_ANTENNA_POSITION.position.altitude - value_slightly_larger_than_half_beam_width
         return [
             replace(ARBITRARY_ANTENNA_POSITION,
-                    altitude=out_of_altitude if i % 2 else ARBITRARY_ANTENNA_POSITION.altitude,
+                    position=replace(ARBITRARY_ANTENNA_POSITION.position,
+                                     altitude=out_of_altitude if i % 2 else ARBITRARY_ANTENNA_POSITION.position.altitude),
                     time=ARBITRARY_ANTENNA_POSITION.time + timedelta(minutes=i))
             for i in range(5)
         ]

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_modulo_360.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_modulo_360.py
@@ -19,9 +19,11 @@ class TestSatellitesWithinMainBeamModulo360:
 
     @staticmethod
     def _run_close_azimuth_due_to_modulus(antenna_azimuth: float, satellite_azimuth: float):
-        antenna_position_at_horizon = replace(ARBITRARY_ANTENNA_POSITION, azimuth=antenna_azimuth)
+        antenna_position_at_horizon = replace(ARBITRARY_ANTENNA_POSITION,
+                                              position=replace(ARBITRARY_ANTENNA_POSITION.position,
+                                                               azimuth=antenna_azimuth))
         satellite_positions = [
-            replace(antenna_position_at_horizon, azimuth=satellite_azimuth)
+            replace(antenna_position_at_horizon, position=replace(antenna_position_at_horizon.position, azimuth=satellite_azimuth))
         ]
         cutoff_time = ARBITRARY_ANTENNA_POSITION.time + timedelta(minutes=1)
         slew = SatellitesWithinMainBeamFilter(facility=ARBITRARY_FACILITY,

--- a/tests/frequency_filter/test_frequency_filter.py
+++ b/tests/frequency_filter/test_frequency_filter.py
@@ -104,7 +104,7 @@ class TestFrequencyFilter:
     def _arbitrary_reservation_with_nonzero_timewindow(self) -> Reservation:
         return Reservation(facility=Facility(elevation=0,
                                              coordinates=Coordinates(latitude=0, longitude=0),
-                                             name='name', azimuth=30),
+                                             name='name'),
                            time=TimeWindow(begin=datetime(year=2001, month=2, day=1, hour=1),
                                            end=datetime(year=2001, month=2, day=1, hour=6)),
                            frequency=FrequencyRange(
@@ -112,5 +112,3 @@ class TestFrequencyFilter:
                                            bandwidth=10
                            )
                            )
-
-

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ from satellite_determination.custom_dataclasses.coordinates import Coordinates
 from satellite_determination.custom_dataclasses.facility import Facility
 from satellite_determination.custom_dataclasses.frequency_range.frequency_range import FrequencyRange
 from satellite_determination.custom_dataclasses.overhead_window import OverheadWindow
+from satellite_determination.custom_dataclasses.position import Position
 from satellite_determination.custom_dataclasses.position_time import PositionTime
 from satellite_determination.custom_dataclasses.reservation import Reservation
 from satellite_determination.custom_dataclasses.satellite.international_designator import InternationalDesignator
@@ -42,7 +43,7 @@ class TestMain:
                                  end=datetime(year=2023, month=3, day=30, hour=14, minute=39, second=36, tzinfo=pytz.UTC))
         return Reservation(
             facility=Facility(
-                antenna_positions=[PositionTime(altitude=32, azimuth=320, time=time_window.begin)],
+                antenna_positions=[PositionTime(position=Position(altitude=32, azimuth=320), time=time_window.begin)],
                 beamwidth=3.5,
                 coordinates=Coordinates(latitude=40.8178049, longitude=-121.4695413),
                 name='ARBITRARY_1',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,8 +19,10 @@ from satellite_determination.main import Main, MainResults
 
 class TestMain:
     def test_arbitrary_inputs_match_expected_output(self):
+        antenna_positions = [PositionTime(position=Position(altitude=32, azimuth=320), time=self._arbitrary_reservation.time.begin)]
         result = Main(reservation=self._arbitrary_reservation,
-                      satellites=self._satellites).run()
+                      satellites=self._satellites,
+                      antenna_direction_path=antenna_positions).run()
         assert result == MainResults(
             satellites_above_horizon=[OverheadWindow(satellite=self._satellite_in_mainbeam,
                                                      overhead_time=TimeWindow(
@@ -43,7 +45,6 @@ class TestMain:
                                  end=datetime(year=2023, month=3, day=30, hour=14, minute=39, second=36, tzinfo=pytz.UTC))
         return Reservation(
             facility=Facility(
-                antenna_positions=[PositionTime(position=Position(altitude=32, azimuth=320), time=time_window.begin)],
                 beamwidth=3.5,
                 coordinates=Coordinates(latitude=40.8178049, longitude=-121.4695413),
                 name='ARBITRARY_1',

--- a/tests/window_finder/definitions.py
+++ b/tests/window_finder/definitions.py
@@ -2,9 +2,8 @@ from satellite_determination.custom_dataclasses.coordinates import Coordinates
 from satellite_determination.custom_dataclasses.facility import Facility
 
 ARBITRARY_FACILITY = Facility(
-    elevation=1.,
-    coordinates=Coordinates(latitude=1., longitude=2.),
     beamwidth=3.,
-    name='name',
-    azimuth=30
+    coordinates=Coordinates(latitude=1., longitude=2.),
+    elevation=1.,
+    name='name'
 )


### PR DESCRIPTION
This separates properties about the observation target from the facility by allowing them to be specified in the configuration of the run.