### PR TITLE
Optimize main by making use of earlier satellite computations

### DIFF
--- a/satellite_determination/main.py
+++ b/satellite_determination/main.py
@@ -27,9 +27,23 @@ class Main:
         self._satellites = satellites
 
     def run(self) -> MainResults:
+        overhead_windows_above_horizon = self._event_finder.get_satellites_above_horizon()
+
+        satellites_above_horizon = []
+        [
+            satellites_above_horizon.append(window.satellite) 
+            for window in overhead_windows_above_horizon if window.satellite not in satellites_above_horizon
+        ]
+
+        event_finder = EventFinderRhodesMill(list_of_satellites=satellites_above_horizon,
+                                             reservation=self._reservation,
+                                             antenna_direction_path=self._antenna_direction_path)
+
+        interference_windows = event_finder.get_satellites_crossing_main_beam()
+        
         return MainResults(
-            satellites_above_horizon=self._event_finder.get_satellites_above_horizon(),
-            interference_windows=self._event_finder.get_satellites_crossing_main_beam()
+            satellites_above_horizon=overhead_windows_above_horizon,
+            interference_windows=interference_windows
         )
 
     @cached_property


### PR DESCRIPTION
In the previous approach, our main function called both get_satellites_crossing_main_beam() and get_satellites_above_horizon(). Each of these functions calculated satellite positions at every time interval across the entire observation window.

By capitalizing on the fact that a satellite must be above the horizon to cross the main beam, we can modify the main function to initially identify the satellites that are positioned above the horizon.

Then, during the subsequent call to get_satellites_crossing_main_beam(), we need to provide only the satellites that were previously identified as being above the horizon, rather than passing the entire list of satellites.

This adjustment leads to an approximate 40-50% reduction in runtime.