### PR TITLE
Include distance of satellite for interference event data

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -69,10 +69,10 @@ def main():
         print(f'Satellite: {window.satellite.name}')
         print(f'Satellite enters view: {window.overhead_time.begin} at '
               f'{window.positions[0].position.azimuth:.2f} '
-              f'Distance: {window.positions[0].position.distance:.2f} km')
+              f'Distance: {window.positions[0].position.distance_km:.2f} km')
         print(f'Satellite leaves view: {window.overhead_time.end} at '
               f'{window.positions[-1].position.azimuth:.2f} '
-              f'Distance: {window.positions[-1].position.distance:.2f} km')
+              f'Distance: {window.positions[-1].position.distance_km:.2f} km')
         print(f'Satellite maximum altitude: {max_alt.position.altitude:.2f}')
         print('__________________________________________________\n')
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -425,10 +425,10 @@ def main():
         print(f'Satellite: {window.satellite.name}')
         print(f'Satellite enters view: {window.overhead_time.begin} at '
               f'{window.positions[0].position.azimuth:.2f} '
-              f'Distance: {window.positions[0].position.distance:.2f} km')
+              f'Distance: {window.positions[0].position.distance_km:.2f} km')
         print(f'Satellite leaves view: {window.overhead_time.end} at '
               f'{window.positions[-1].position.azimuth:.2f} '
-              f'Distance: {window.positions[-1].position.distance:.2f} km')
+              f'Distance: {window.positions[-1].position.distance_km:.2f} km')
         print(f'Satellite maximum altitude: {max_alt.position.altitude:.2f}')
         print('__________________________________________________\n')
 

--- a/sopp/custom_dataclasses/position.py
+++ b/sopp/custom_dataclasses/position.py
@@ -8,16 +8,16 @@ class Position:
     Represents a position relative to an observer on Earth.
 
     Attributes:
-    - altitude (float): The altitude angle of the object in degrees. It ranges
+    + altitude (float): The altitude angle of the object in degrees. It ranges
       from 0° at the horizon to 90° directly overhead at the zenith. A negative
       altitude means the satellite is below the horizon.
-    - azimuth (float): The azimuth angle of the object in degrees, measured
+    + azimuth (float): The azimuth angle of the object in degrees, measured
       clockwise around the horizon. It runs from 0° (geographic north) through
       east (90°), south (180°), and west (270°) before returning to the north.
-    - distance (Optional[float]): The straight-line distance between the
+    + distance (Optional[float]): The straight-line distance between the
       object and the observer in kilometers. If not provided, it is set to
       None.
     """
     altitude: float
     azimuth: float
-    distance: Optional[float] = None
+    distance_km: Optional[float] = None

--- a/sopp/event_finder/event_finder_rhodesmill/support/satellite_positions_with_respect_to_facility_retriever/satellite_positions_with_respect_to_facility_retriever_rhodesmill.py
+++ b/sopp/event_finder/event_finder_rhodesmill/support/satellite_positions_with_respect_to_facility_retriever/satellite_positions_with_respect_to_facility_retriever_rhodesmill.py
@@ -29,10 +29,10 @@ class SatellitePositionsWithRespectToFacilityRetrieverRhodesmill(SatellitePositi
 
         return [
             PositionTime(
-                Position(altitude=altitude, azimuth=azimuth, distance=distance),
+                Position(altitude=altitude, azimuth=azimuth, distance_km=distance_km),
                 time=time
             )
-            for altitude, azimuth, distance, time in zip(altitude.degrees, azimuth.degrees, distance.km, self._datetimes)
+            for altitude, azimuth, distance_km, time in zip(altitude.degrees, azimuth.degrees, distance.km, self._datetimes)
         ]
 
     def _calculate_facility_latlon(self):


### PR DESCRIPTION
This PR adds satellite distance data for interference events and updates the documentation accordingly.

An optional distance attribute was added to the `Position` dataclass. Now, when interference event data is generated via a call to `get_satellites_crossing_main_beam`, or `get_satellites_above_horizon` the distance (in km) between the satellite and the observer is returned along with the altitude and azimuth.