### PR TITLE
fix: Use default_factory for initialization of default field in dataclasses

### DIFF
--- a/sopp/custom_dataclasses/configuration.py
+++ b/sopp/custom_dataclasses/configuration.py
@@ -14,7 +14,7 @@ class Configuration:
     reservation: Reservation
     satellites: List[Satellite]
     antenna_direction_path: List[PositionTime]
-    runtime_settings: Optional[RuntimeSettings] = field(default_factory=RuntimeSettings)
+    runtime_settings: RuntimeSettings = field(default_factory=RuntimeSettings)
 
     def __str__(self):
         return (

--- a/sopp/custom_dataclasses/configuration_file.py
+++ b/sopp/custom_dataclasses/configuration_file.py
@@ -11,7 +11,7 @@ from sopp.custom_dataclasses.runtime_settings import RuntimeSettings
 @dataclass
 class ConfigurationFile:
     reservation: Reservation
-    runtime_settings: Optional[RuntimeSettings] = field(default_factory=RuntimeSettings)
+    runtime_settings: RuntimeSettings = field(default_factory=RuntimeSettings)
     antenna_position_times: Optional[List[PositionTime]] = None
     observation_target: Optional[ObservationTarget] = None
     static_antenna_position: Optional[Position] = None


### PR DESCRIPTION
This was an error reported by a user. I will create an issue as we should start testing against python 3.11 and 3.12.

This fixes a value error raised in python3.12 for two dataclasses:
`ValueError: mutable default <class 'sopp.custom_dataclasses.runtime_settings.RuntimeSettings'> for field runtime_settings is not allowed: use default_factory`