### PR TITLE
refactor: Remove dependency on pytz

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 name = "sopp"
 dynamic = ["version"]
 dependencies = [
-    "pytz~=2022.7",
     "sgp4~=2.21",
     "skyfield~=1.47",
     "requests~=2.31.0",

--- a/sopp/event_finder/support/overhead_window_from_events.py
+++ b/sopp/event_finder/support/overhead_window_from_events.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import List
-import pytz
 from sopp.custom_dataclasses.overhead_window import OverheadWindow
 from sopp.custom_dataclasses.reservation import Reservation
 from sopp.custom_dataclasses.satellite.satellite import Satellite

--- a/sopp/utilities.py
+++ b/sopp/utilities.py
@@ -1,13 +1,12 @@
 import json
 import os
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from io import TextIOWrapper
 from pathlib import Path
 from typing import ContextManager, List, Optional, Union
 from uuid import uuid4
 
-import pytz
 from dateutil import parser
 
 
@@ -25,12 +24,12 @@ def temporary_file(filepath: Optional[Path] = None) -> ContextManager[TextIOWrap
 
 
 def convert_datetime_to_utc(localtime: datetime) -> datetime:
-    if localtime.tzinfo == pytz.UTC:
+    if localtime.tzinfo == timezone.utc:
         return localtime
     elif localtime.tzinfo is None:
-        return localtime.replace(tzinfo=pytz.UTC)
+        return localtime.replace(tzinfo=timezone.utc)
     else:
-        return localtime.astimezone(pytz.UTC)
+        return localtime.astimezone(timezone.utc)
 
 
 def read_datetime_string_as_utc(string_value: str) -> datetime:

--- a/tests/builder/test_configuration_builder.py
+++ b/tests/builder/test_configuration_builder.py
@@ -1,7 +1,6 @@
 import pytest
 
-from datetime import datetime
-import pytz
+from datetime import datetime, timezone
 
 from sopp.builder.configuration_builder import ConfigurationBuilder
 from sopp.custom_dataclasses.configuration import Configuration
@@ -96,20 +95,20 @@ class TestConfigurationBuilder:
         )
 
         assert builder.time_window == TimeWindow(
-            begin=datetime(2023, 11, 15, 8, 0, tzinfo=pytz.UTC),
-            end=datetime(2023, 11, 15, 8, 30, tzinfo=pytz.UTC),
+            begin=datetime(2023, 11, 15, 8, 0, tzinfo=timezone.utc),
+            end=datetime(2023, 11, 15, 8, 30, tzinfo=timezone.utc),
         )
 
     def test_set_time_window_datetime(self):
         builder = ConfigurationBuilder()
         builder.set_time_window(
-            begin=datetime(2023, 11, 15, 8, 0, tzinfo=pytz.UTC),
-            end=datetime(2023, 11, 15, 8, 30, tzinfo=pytz.UTC),
+            begin=datetime(2023, 11, 15, 8, 0, tzinfo=timezone.utc),
+            end=datetime(2023, 11, 15, 8, 30, tzinfo=timezone.utc),
         )
 
         assert builder.time_window == TimeWindow(
-            begin=datetime(2023, 11, 15, 8, 0, tzinfo=pytz.UTC),
-            end=datetime(2023, 11, 15, 8, 30, tzinfo=pytz.UTC),
+            begin=datetime(2023, 11, 15, 8, 0, tzinfo=timezone.utc),
+            end=datetime(2023, 11, 15, 8, 30, tzinfo=timezone.utc),
         )
 
     def test_set_satellites(self, monkeypatch):
@@ -245,7 +244,7 @@ def mock_satellite_loader(monkeypatch):
 def expected_position_time():
     return PositionTime(
         position=Position(altitude=.0, azimuth=.1),
-        time=datetime(2023, 11, 15, 8, 0, tzinfo=pytz.UTC),
+        time=datetime(2023, 11, 15, 8, 0, tzinfo=timezone.utc),
     )
 
 def expected_reservation():
@@ -257,8 +256,8 @@ def expected_reservation():
             name='HCRO'
         ),
         time=TimeWindow(
-            begin=datetime(2023, 11, 15, 8, 0, tzinfo=pytz.UTC),
-            end=datetime(2023, 11, 15, 8, 30, tzinfo=pytz.UTC),
+            begin=datetime(2023, 11, 15, 8, 0, tzinfo=timezone.utc),
+            end=datetime(2023, 11, 15, 8, 30, tzinfo=timezone.utc),
         ),
         frequency=FrequencyRange(
             bandwidth=10,

--- a/tests/config_file_loader/test_config_file_loader_default_argument.py
+++ b/tests/config_file_loader/test_config_file_loader_default_argument.py
@@ -1,10 +1,9 @@
 import os
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-import pytz
 
 from sopp.config_file_loader.config_file_loader_factory import get_config_file_object
 from sopp.config_file_loader.support.config_file_loader_base import ConfigFileLoaderBase
@@ -59,8 +58,8 @@ class TestConfigFileDefaultArgument:
                     name='ARBITRARY_2',
                     elevation=1000,
                 ),
-                time=TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=10, tzinfo=pytz.UTC),
-                                end=datetime(year=2023, month=3, day=30, hour=11, tzinfo=pytz.UTC)),
+                time=TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=10, tzinfo=timezone.utc),
+                                end=datetime(year=2023, month=3, day=30, hour=11, tzinfo=timezone.utc)),
                 frequency=FrequencyRange(
                     frequency=135,
                     bandwidth=10

--- a/tests/config_file_loader/test_config_file_loader_provided_argument.py
+++ b/tests/config_file_loader/test_config_file_loader_provided_argument.py
@@ -1,8 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
-import pytz
 
 from sopp.config_file_loader.config_file_loader_factory import get_config_file_object
 from sopp.config_file_loader.support.config_file_loader_base import ConfigFileLoaderBase
@@ -33,8 +32,8 @@ class TestConfigFileProvidedArgument:
                     name='ARBITRARY_1',
                     elevation=1000,
                 ),
-                time=TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=10, tzinfo=pytz.UTC),
-                                end=datetime(year=2023, month=3, day=30, hour=11, tzinfo=pytz.UTC)),
+                time=TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=10, tzinfo=timezone.utc),
+                                end=datetime(year=2023, month=3, day=30, hour=11, tzinfo=timezone.utc)),
                 frequency=FrequencyRange(
                     frequency=135,
                     bandwidth=10
@@ -49,9 +48,9 @@ class TestConfigFileProvidedArgument:
         config = self._get_config_file_object(config_filename='config_file_json/arbitrary_config_file_with_antenna_position_times.json')
         assert config.configuration.antenna_position_times == [
             PositionTime(position=Position(altitude=.0, azimuth=.1),
-                         time=datetime(year=2023, month=3, day=30, hour=10, minute=1, tzinfo=pytz.UTC)),
+                         time=datetime(year=2023, month=3, day=30, hour=10, minute=1, tzinfo=timezone.utc)),
             PositionTime(position=Position(altitude=.1, azimuth=.2),
-                         time=datetime(year=2023, month=3, day=30, hour=10, minute=2, tzinfo=pytz.UTC))
+                         time=datetime(year=2023, month=3, day=30, hour=10, minute=2, tzinfo=timezone.utc))
         ]
 
     def test_json_runtime_settings(self):

--- a/tests/event_finder/event_finder_rhodesmill/definitions.py
+++ b/tests/event_finder/event_finder_rhodesmill/definitions.py
@@ -1,6 +1,4 @@
-from datetime import datetime, timedelta
-
-import pytz
+from datetime import datetime, timedelta, timezone
 
 from sopp.custom_dataclasses.coordinates import Coordinates
 from sopp.custom_dataclasses.facility import Facility
@@ -10,9 +8,9 @@ from sopp.custom_dataclasses.overhead_window import OverheadWindow
 
 ARBITRARY_FACILITY = Facility(coordinates=Coordinates(latitude=0, longitude=0))
 
-ARBITRARY_ANTENNA_POSITION = PositionTime(position=Position(altitude=100, azimuth=100), time=datetime.now(tz=pytz.UTC))
+ARBITRARY_ANTENNA_POSITION = PositionTime(position=Position(altitude=100, azimuth=100), time=datetime.now(tz=timezone.utc))
 
-ARBITRARY_SATELLITE_POSITION = PositionTime(position=Position(altitude=100, azimuth=100), time=datetime.now(tz=pytz.UTC))
+ARBITRARY_SATELLITE_POSITION = PositionTime(position=Position(altitude=100, azimuth=100), time=datetime.now(tz=timezone.utc))
 
 def create_overhead_window(satellite, altitude, azimuth, start_time, num_positions):
     positions = [

--- a/tests/event_finder/event_finder_rhodesmill/support/test_satellite_positions_with_respect_to_facility_retriever_rhodesmill.py
+++ b/tests/event_finder/event_finder_rhodesmill/support/test_satellite_positions_with_respect_to_facility_retriever_rhodesmill.py
@@ -1,7 +1,5 @@
 from dataclasses import replace
-from datetime import datetime
-
-import pytz
+from datetime import datetime, timezone
 
 from sopp.custom_dataclasses.coordinates import Coordinates
 from sopp.custom_dataclasses.facility import Facility
@@ -16,19 +14,19 @@ from sopp.event_finder.event_finder_rhodesmill.support.satellite_positions_with_
 
 class TestSatellitePositionsWithRespectToFacilityRetrieverRhodesmill:
     def test_altitude_can_be_negative(self):
-        timestamp = datetime(year=2023, month=6, day=7, tzinfo=pytz.UTC)
+        timestamp = datetime(year=2023, month=6, day=7, tzinfo=timezone.utc)
         facility = Facility(Coordinates(latitude=0, longitude=0))
         position = self._get_satellite_position(facility=facility, timestamp=timestamp)
         assert position.position.altitude < 0
 
     def test_azimuth_can_be_greater_than_180(self):
-        timestamp = datetime(year=2023, month=6, day=7, tzinfo=pytz.UTC)
+        timestamp = datetime(year=2023, month=6, day=7, tzinfo=timezone.utc)
         facility = Facility(Coordinates(latitude=0, longitude=0))
         position = self._get_satellite_position(facility=facility, timestamp=timestamp)
         assert position.position.azimuth > 180
 
     def test_altitude_decreases_as_elevation_increases(self):
-        timestamp = datetime(year=2023, month=6, day=7, tzinfo=pytz.UTC)
+        timestamp = datetime(year=2023, month=6, day=7, tzinfo=timezone.utc)
         facility_where_satellite_has_zero_altitude = Facility(Coordinates(latitude=0, longitude=-24.66605))
         same_facility_with_higher_elevation = replace(facility_where_satellite_has_zero_altitude, elevation=1000)
         position_at_horizon = self._get_satellite_position(facility=facility_where_satellite_has_zero_altitude,

--- a/tests/event_finder/event_finder_rhodesmill/test_event_finder_reservation_start_time.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_event_finder_reservation_start_time.py
@@ -1,6 +1,4 @@
-from datetime import datetime, timedelta
-
-import pytz
+from datetime import datetime, timedelta, timezone
 
 from sopp.custom_dataclasses.coordinates import Coordinates
 from sopp.custom_dataclasses.facility import Facility
@@ -20,7 +18,7 @@ from tests.event_finder.event_finder_rhodesmill.definitions import create_overhe
 class TestEventFinderReservationStartTime:
     def test_reservation_begins_part_way_through_antenna_position_time(self):
         arbitrary_satellite = Satellite(name='arbitrary')
-        arbitrary_datetime = datetime.now(tz=pytz.utc)
+        arbitrary_datetime = datetime.now(tz=timezone.utc)
         arbitrary_time_window = TimeWindow(begin=arbitrary_datetime,
                                            end=arbitrary_datetime + timedelta(seconds=2))
         arbitrary_reservation = Reservation(facility=Facility(coordinates=Coordinates(latitude=0, longitude=0)),
@@ -46,7 +44,7 @@ class TestEventFinderReservationStartTime:
 
     def test_antenna_positions_that_end_before_reservation_starts_are_not_included(self):
         arbitrary_satellite = Satellite(name='arbitrary')
-        arbitrary_datetime = datetime.now(tz=pytz.utc)
+        arbitrary_datetime = datetime.now(tz=timezone.utc)
         arbitrary_time_window = TimeWindow(begin=arbitrary_datetime,
                                            end=arbitrary_datetime + timedelta(seconds=2))
         arbitrary_reservation = Reservation(facility=Facility(coordinates=Coordinates(latitude=0, longitude=0)),

--- a/tests/event_finder/event_finder_rhodesmill/test_event_finder_rhodesmill.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_event_finder_rhodesmill.py
@@ -1,5 +1,4 @@
-import pytz
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 
 from sopp.custom_dataclasses.coordinates import Coordinates
@@ -37,7 +36,7 @@ class SatellitePositionsWithRespectToFacilityRetrieverStub:
 class TestEventFinderRhodesmill:
     def test_single_satellite(self):
         arbitrary_satellite = Satellite(name='arbitrary')
-        arbitrary_datetime = datetime.now(tz=pytz.utc)
+        arbitrary_datetime = datetime.now(tz=timezone.utc)
         arbitrary_time_window = TimeWindow(begin=arbitrary_datetime,
                                            end=arbitrary_datetime + timedelta(seconds=2))
         arbitrary_reservation = Reservation(facility=Facility(coordinates=Coordinates(latitude=0, longitude=0)),
@@ -58,7 +57,7 @@ class TestEventFinderRhodesmill:
 
     def test_multiple_satellites(self):
         arbitrary_satellites = [Satellite(name='arbitrary'), Satellite(name='arbitrary2')]
-        arbitrary_datetime = datetime.now(tz=pytz.utc)
+        arbitrary_datetime = datetime.now(tz=timezone.utc)
         arbitrary_time_window = TimeWindow(begin=arbitrary_datetime,
                                            end=arbitrary_datetime + timedelta(seconds=2))
         arbitrary_reservation = Reservation(facility=Facility(coordinates=Coordinates(latitude=0, longitude=0)),
@@ -80,7 +79,7 @@ class TestEventFinderRhodesmill:
 
     def test_multiple_antenna_positions_with_azimuth_filtering(self):
         arbitrary_satellite = Satellite(name='arbitrary')
-        arbitrary_datetime = datetime.now(tz=pytz.utc)
+        arbitrary_datetime = datetime.now(tz=timezone.utc)
 
         arbitrary_time_window = TimeWindow(
             begin=arbitrary_datetime,

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_above_horizon.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_above_horizon.py
@@ -1,7 +1,5 @@
 from dataclasses import replace
-from datetime import timedelta, datetime
-
-import pytz
+from datetime import timedelta, datetime, timezone
 
 from sopp.custom_dataclasses.time_window import TimeWindow
 from sopp.custom_dataclasses.position import Position
@@ -143,8 +141,8 @@ class TestSatellitesAboveHorizon:
 
     def satellite_above_horizon(self, time_offset=0):
         time_offset = timedelta(minutes=time_offset)
-        return PositionTime(position=Position(altitude=100, azimuth=100), time=datetime.now(tz=pytz.UTC) + time_offset)
+        return PositionTime(position=Position(altitude=100, azimuth=100), time=datetime.now(tz=timezone.utc) + time_offset)
 
     def satellite_below_horizon(self, time_offset=0):
         time_offset = timedelta(minutes=time_offset)
-        return PositionTime(position=Position(altitude=-100, azimuth=100), time=datetime.now(tz=pytz.UTC) + time_offset)
+        return PositionTime(position=Position(altitude=-100, azimuth=100), time=datetime.now(tz=timezone.utc) + time_offset)

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter.py
@@ -1,8 +1,6 @@
 from dataclasses import replace
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
-
-import pytz
 
 from sopp.custom_dataclasses.position_time import PositionTime
 from sopp.custom_dataclasses.time_window import TimeWindow
@@ -165,7 +163,7 @@ class TestSatellitesWithinMainBeam:
 
     @property
     def _arbitrary_cutoff_time(self) -> datetime:
-        return datetime.now(tz=pytz.UTC)
+        return datetime.now(tz=timezone.utc)
 
     @staticmethod
     def _replace_antenna_position(antenna_position: PositionTime,

--- a/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_altitude.py
+++ b/tests/event_finder/event_finder_rhodesmill/test_satellites_within_main_beam_filter_altitude.py
@@ -1,9 +1,7 @@
 from dataclasses import replace
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from typing import List
-
-import pytz
 
 from sopp.custom_dataclasses.position_time import PositionTime
 from sopp.custom_dataclasses.position import Position
@@ -52,4 +50,4 @@ class TestSatellitesWithinMainBeamAltitude:
 
     @cached_property
     def _arbitrary_cutoff_time(self) -> datetime:
-        return datetime.now(tz=pytz.UTC)
+        return datetime.now(tz=timezone.utc)

--- a/tests/graph_generator/test_polar_graph_generator.py
+++ b/tests/graph_generator/test_polar_graph_generator.py
@@ -1,7 +1,6 @@
 import pytest
-import pytz
 import numpy as np
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sopp.graph_generator.graph_polar import GraphGeneratorPolar
 from sopp.custom_dataclasses.position_time import PositionTime
@@ -10,19 +9,19 @@ from sopp.custom_dataclasses.position import Position
 observation_data = [
     PositionTime(
         position=Position(altitude=0.037991772033771, azimuth=225.42667523243927),
-        time=datetime(2023, 9, 15, 3, 13, 31, tzinfo=pytz.utc)),
+        time=datetime(2023, 9, 15, 3, 13, 31, tzinfo=timezone.utc)),
     PositionTime(
         position=Position(altitude=0.1004175887946367, azimuth=225.4135720960317),
-        time=datetime(2023, 9, 15, 3, 13, 32, tzinfo=pytz.utc)),
+        time=datetime(2023, 9, 15, 3, 13, 32, tzinfo=timezone.utc)),
     PositionTime(
         position=Position(altitude=0.16302916811324802, azimuth=225.40037964262117),
-        time=datetime(2023, 9, 15, 3, 13, 33, tzinfo=pytz.utc)),
+        time=datetime(2023, 9, 15, 3, 13, 33, tzinfo=timezone.utc)),
     PositionTime(
         position=Position(altitude=0.22582815942805465, azimuth=225.38709702253257),
-        time=datetime(2023, 9, 15, 3, 13, 34, tzinfo=pytz.utc)),
+        time=datetime(2023, 9, 15, 3, 13, 34, tzinfo=timezone.utc)),
     PositionTime(
         position=Position(altitude=0.28881623145852403, azimuth=225.37372337554274),
-        time=datetime(2023, 9, 15, 3, 13, 35, tzinfo=pytz.utc))
+        time=datetime(2023, 9, 15, 3, 13, 35, tzinfo=timezone.utc))
 ]
 
 

--- a/tests/test_datetime_utilities.py
+++ b/tests/test_datetime_utilities.py
@@ -1,5 +1,4 @@
-import pytz
-from datetime import datetime
+from datetime import datetime, timezone
 import pytest
 
 from sopp.utilities import read_datetime_string_as_utc, parse_time_and_convert_to_utc
@@ -7,17 +6,17 @@ from sopp.utilities import read_datetime_string_as_utc, parse_time_and_convert_t
 
 class TestDatetimeUtilities:
     def test_read_datetime_string_as_utc_with_microseconds(self):
-        expected_datetime = datetime(2023, 12, 27, 19, 0, 0, 0, tzinfo=pytz.UTC)
+        expected_datetime = datetime(2023, 12, 27, 19, 0, 0, 0, tzinfo=timezone.utc)
 
         assert read_datetime_string_as_utc('2023-12-27T19:00:00.0') == expected_datetime
 
     def test_read_datetime_string_as_utc_without_microseconds(self):
-        expected_datetime = datetime(2023, 12, 27, 19, 0, 0, 0, tzinfo=pytz.UTC)
+        expected_datetime = datetime(2023, 12, 27, 19, 0, 0, 0, tzinfo=timezone.utc)
 
         assert read_datetime_string_as_utc('2023-12-27T19:00:00') == expected_datetime
 
     def test_read_datetime_string_as_utc_with_timezone(self):
-        expected_datetime = datetime(2023, 12, 27, 12, 0, 0, 0, tzinfo=pytz.UTC)
+        expected_datetime = datetime(2023, 12, 27, 12, 0, 0, 0, tzinfo=timezone.utc)
 
         assert read_datetime_string_as_utc('2023-12-27T5:00:00-07:00') == expected_datetime
 
@@ -27,15 +26,15 @@ class TestDatetimeUtilities:
 
     def test_read_datetime_with_datetime_raises_type_error(self):
         with pytest.raises(TypeError) as _:
-            read_datetime_string_as_utc(datetime(2023, 12, 27, 12, 0, 0, 0, tzinfo=pytz.UTC))
+            read_datetime_string_as_utc(datetime(2023, 12, 27, 12, 0, 0, 0, tzinfo=timezone.utc))
 
     def test_parse_time_and_convert_to_utc_with_datetime(self):
-        expected_datetime = datetime(2023, 12, 27, 12, 0, 0, 0, tzinfo=pytz.UTC)
+        expected_datetime = datetime(2023, 12, 27, 12, 0, 0, 0, tzinfo=timezone.utc)
 
         assert parse_time_and_convert_to_utc(expected_datetime) == expected_datetime
 
     def test_parse_time_and_convert_to_utc_with_string(self):
-        expected_datetime = datetime(2023, 12, 27, 12, 0, 0, 0, tzinfo=pytz.UTC)
+        expected_datetime = datetime(2023, 12, 27, 12, 0, 0, 0, tzinfo=timezone.utc)
 
         assert parse_time_and_convert_to_utc('2023-12-27T5:00:00-07:00') == expected_datetime
 

--- a/tests/test_sopp.py
+++ b/tests/test_sopp.py
@@ -1,6 +1,5 @@
 import pytest
-import pytz
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sopp.sopp import Sopp
 from sopp.custom_dataclasses.overhead_window import OverheadWindow
@@ -53,19 +52,19 @@ class TestSopp:
                 positions=[
                     PositionTime(
                         position=Position(altitude=31.92827689000652, azimuth=322.2152123600712),
-                        time=datetime(2023, 3, 30, 14, 39, 32, tzinfo=pytz.UTC)
+                        time=datetime(2023, 3, 30, 14, 39, 32, tzinfo=timezone.utc)
                     ),
                     PositionTime(
                         position=Position(altitude=32.10476096624609, azimuth=321.73184343501606),
-                        time=datetime(2023, 3, 30, 14, 39, 33, tzinfo=pytz.UTC)
+                        time=datetime(2023, 3, 30, 14, 39, 33, tzinfo=timezone.utc)
                     ),
                     PositionTime(
                         position=Position(altitude=32.28029629612362, azimuth=321.24277001092725),
-                        time=datetime(2023, 3, 30, 14, 39, 34, tzinfo=pytz.UTC)
+                        time=datetime(2023, 3, 30, 14, 39, 34, tzinfo=timezone.utc)
                     ),
                     PositionTime(
                         position=Position(altitude=32.45481011166138, azimuth=320.74796378603236),
-                        time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=pytz.UTC)
+                        time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=timezone.utc)
                     )
                 ]
             ),
@@ -74,7 +73,7 @@ class TestSopp:
                 positions=[
                     PositionTime(
                         position=Position(altitude=0.011527751634842421, azimuth=31.169677715036304),
-                        time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=pytz.UTC)
+                        time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=timezone.utc)
                     )
                 ]
             )
@@ -86,15 +85,15 @@ class TestSopp:
                 positions=[
                     PositionTime(
                         position=Position(altitude=32.10476096624609, azimuth=321.73184343501606),
-                        time=datetime(2023, 3, 30, 14, 39, 33, tzinfo=pytz.UTC)
+                        time=datetime(2023, 3, 30, 14, 39, 33, tzinfo=timezone.utc)
                     ),
                     PositionTime(
                         position=Position(altitude=32.28029629612362, azimuth=321.24277001092725),
-                        time=datetime(2023, 3, 30, 14, 39, 34, tzinfo=pytz.UTC)
+                        time=datetime(2023, 3, 30, 14, 39, 34, tzinfo=timezone.utc)
                     ),
                     PositionTime(
                         position=Position(altitude=32.45481011166138, azimuth=320.74796378603236),
-                        time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=pytz.UTC)
+                        time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=timezone.utc)
                     )
                 ]
             )
@@ -120,8 +119,8 @@ class TestSopp:
 
     @property
     def _arbitrary_reservation(self) -> Reservation:
-        time_window = TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=14, minute=39, second=32, tzinfo=pytz.UTC),
-                                 end=datetime(year=2023, month=3, day=30, hour=14, minute=39, second=36, tzinfo=pytz.UTC))
+        time_window = TimeWindow(begin=datetime(year=2023, month=3, day=30, hour=14, minute=39, second=32, tzinfo=timezone.utc),
+                                 end=datetime(year=2023, month=3, day=30, hour=14, minute=39, second=36, tzinfo=timezone.utc))
         return Reservation(
             facility=Facility(
                 beamwidth=3.5,
@@ -291,19 +290,19 @@ def overhead_windows():
             positions=[
                 PositionTime(
                     position=Position(altitude=31.92827689000652, azimuth=322.2152123600712),
-                    time=datetime(2023, 3, 30, 14, 39, 32, tzinfo=pytz.UTC)
+                    time=datetime(2023, 3, 30, 14, 39, 32, tzinfo=timezone.utc)
                 ),
                 PositionTime(
                     position=Position(altitude=32.10476096624609, azimuth=321.73184343501606),
-                    time=datetime(2023, 3, 30, 14, 39, 33, tzinfo=pytz.UTC)
+                    time=datetime(2023, 3, 30, 14, 39, 33, tzinfo=timezone.utc)
                 ),
                 PositionTime(
                     position=Position(altitude=32.28029629612362, azimuth=321.24277001092725),
-                    time=datetime(2023, 3, 30, 14, 39, 34, tzinfo=pytz.UTC)
+                    time=datetime(2023, 3, 30, 14, 39, 34, tzinfo=timezone.utc)
                 ),
                 PositionTime(
                     position=Position(altitude=32.45481011166138, azimuth=320.74796378603236),
-                    time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=pytz.UTC)
+                    time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=timezone.utc)
                 )
             ]
         ),
@@ -312,7 +311,7 @@ def overhead_windows():
             positions=[
                 PositionTime(
                     position=Position(altitude=0.011527751634842421, azimuth=31.169677715036304),
-                    time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=pytz.UTC)
+                    time=datetime(2023, 3, 30, 14, 39, 35, tzinfo=timezone.utc)
                 )
             ]
         )

--- a/tests/window_finder/test_sorted_by_least_number_of_satellites.py
+++ b/tests/window_finder/test_sorted_by_least_number_of_satellites.py
@@ -1,10 +1,9 @@
 from dataclasses import replace
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 from pathlib import Path
 
 import pytest
-import pytz
 from sopp.utilities import get_script_directory
 from sopp.custom_dataclasses.frequency_range.frequency_range import FrequencyRange
 from sopp.custom_dataclasses.frequency_range.support.get_frequency_data_from_csv import \
@@ -49,31 +48,31 @@ class TestSortedByLeastNumberOfSatellites:
     def _expected_suggestions_search(self) -> List[SuggestedReservation]:
         return [
             SuggestedReservation(
-                suggested_start_time=datetime(year=2022, month=11, day=20, hour=1, tzinfo=pytz.UTC),
+                suggested_start_time=datetime(year=2022, month=11, day=20, hour=1, tzinfo=timezone.utc),
                 ideal_reservation=self._ideal_reservation,
                 overhead_satellites=[]
             ),
 
             SuggestedReservation(
-                suggested_start_time=datetime(year=2022, month=11, day=20, hour=5, tzinfo=pytz.UTC),
+                suggested_start_time=datetime(year=2022, month=11, day=20, hour=5, tzinfo=timezone.utc),
                 ideal_reservation=self._ideal_reservation,
                 overhead_satellites=[]
             ),
 
             SuggestedReservation(
-                suggested_start_time=datetime(year=2022, month=11, day=19, hour=17, tzinfo=pytz.UTC),
+                suggested_start_time=datetime(year=2022, month=11, day=19, hour=17, tzinfo=timezone.utc),
                 ideal_reservation=self._ideal_reservation,
                 overhead_satellites=[]
             ),
 
             SuggestedReservation(
-                suggested_start_time=datetime(year=2022, month=11, day=20, hour=13, tzinfo=pytz.UTC),
+                suggested_start_time=datetime(year=2022, month=11, day=20, hour=13, tzinfo=timezone.utc),
                 ideal_reservation=self._ideal_reservation,
                 overhead_satellites=[]
             ),
 
             SuggestedReservation(
-                suggested_start_time=datetime(year=2022, month=11, day=19, hour=21, tzinfo=pytz.UTC),
+                suggested_start_time=datetime(year=2022, month=11, day=19, hour=21, tzinfo=timezone.utc),
                 ideal_reservation=self._ideal_reservation,
                 overhead_satellites=[OverheadWindow(
                     satellite=Satellite(
@@ -107,15 +106,15 @@ class TestSortedByLeastNumberOfSatellites:
 
                     ),
                     overhead_time=TimeWindow(
-                        begin=datetime(year=2022, month=11, day=19, hour=23, minute=45, second=7, microsecond=540745, tzinfo=pytz.UTC),
-                        end=datetime(year=2022, month=11, day=19, hour=23, minute=45, second=21, microsecond=540745, tzinfo=pytz.UTC)
+                        begin=datetime(year=2022, month=11, day=19, hour=23, minute=45, second=7, microsecond=540745, tzinfo=timezone.utc),
+                        end=datetime(year=2022, month=11, day=19, hour=23, minute=45, second=21, microsecond=540745, tzinfo=timezone.utc)
                     )
 
             )]
             ),
 
             SuggestedReservation(
-                suggested_start_time=datetime(year=2022, month=11, day=20, hour=9, tzinfo=pytz.UTC),
+                suggested_start_time=datetime(year=2022, month=11, day=20, hour=9, tzinfo=timezone.utc),
                 ideal_reservation=self._ideal_reservation,
                 overhead_satellites=[OverheadWindow(
                     satellite=Satellite(
@@ -149,8 +148,8 @@ class TestSortedByLeastNumberOfSatellites:
 
                     ),
                     overhead_time=TimeWindow(
-                        begin=datetime(year=2022, month=11, day=20, hour=12, minute=57, second=59, microsecond=107439, tzinfo=pytz.UTC),
-                        end=datetime(year=2022, month=11, day=20, hour=12, minute=58, second=47, microsecond=107439, tzinfo=pytz.UTC)
+                        begin=datetime(year=2022, month=11, day=20, hour=12, minute=57, second=59, microsecond=107439, tzinfo=timezone.utc),
+                        end=datetime(year=2022, month=11, day=20, hour=12, minute=58, second=47, microsecond=107439, tzinfo=timezone.utc)
 
                     )
 
@@ -180,7 +179,7 @@ class TestSortedByLeastNumberOfSatellites:
     def _ideal_reservation(self) -> Reservation:
         return Reservation(
             facility=ARBITRARY_FACILITY,
-            time=TimeWindow(begin=datetime(year=2022, month=11, day=20, hour=1, tzinfo=pytz.UTC), end=datetime(year=2022, month=11, day=20, hour=5, tzinfo=pytz.UTC)),
+            time=TimeWindow(begin=datetime(year=2022, month=11, day=20, hour=1, tzinfo=timezone.utc), end=datetime(year=2022, month=11, day=20, hour=5, tzinfo=timezone.utc)),
             frequency=FrequencyRange(
                 frequency=None,
                 bandwidth=None


### PR DESCRIPTION
pytz maintainer [recommends](https://pypi.org/project/pytz/) to use the python standard library support for timezones for any python packages that support only python 3.9+.

This PR replaces pytz with the datetime.timezone, and removes the pytz dependency. 