### PR TITLE
refactor: Apply future annotations and TYPE_CHECKING pattern

### DIFF
--- a/src/sopp/config/builder.py
+++ b/src/sopp/config/builder.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from sopp.config.loaders import ConfigFileLoaderBase, ConfigFileLoaderJson
 from sopp.filtering.filterer import Filterer
@@ -15,10 +18,12 @@ from sopp.models.ground.config import (
 )
 from sopp.models.ground.facility import Facility
 from sopp.models.ground.target import ObservationTarget
-from sopp.models.ground.trajectory import AntennaTrajectory
 from sopp.models.reservation import Reservation
-from sopp.models.satellite.satellite import Satellite
 from sopp.utils.helpers import parse_time_and_convert_to_utc
+
+if TYPE_CHECKING:
+    from sopp.models.ground.trajectory import AntennaTrajectory
+    from sopp.models.satellite.satellite import Satellite
 
 
 class ConfigurationBuilder:
@@ -43,7 +48,7 @@ class ConfigurationBuilder:
         elevation: float,
         name: str,
         beamwidth: float,
-    ) -> "ConfigurationBuilder":
+    ) -> ConfigurationBuilder:
         self.facility = Facility(
             Coordinates(latitude=latitude, longitude=longitude),
             elevation=elevation,
@@ -63,7 +68,7 @@ class ConfigurationBuilder:
         self,
         begin: str | datetime,
         end: str | datetime,
-    ) -> "ConfigurationBuilder":
+    ) -> ConfigurationBuilder:
         self.time_window = TimeWindow(
             begin=parse_time_and_convert_to_utc(begin),
             end=parse_time_and_convert_to_utc(end),
@@ -77,7 +82,7 @@ class ConfigurationBuilder:
         altitude: float | None = None,
         azimuth: float | None = None,
         custom_antenna_trajectory: AntennaTrajectory | None = None,
-    ) -> "ConfigurationBuilder":
+    ) -> ConfigurationBuilder:
         # Option 1: Custom
         if custom_antenna_trajectory:
             self.antenna_config = CustomTrajectoryConfig(custom_antenna_trajectory)
@@ -102,13 +107,13 @@ class ConfigurationBuilder:
             )
         return self
 
-    def set_satellites(self, satellites: list[Satellite]) -> "ConfigurationBuilder":
+    def set_satellites(self, satellites: list[Satellite]) -> ConfigurationBuilder:
         self.satellites = satellites
         return self
 
     def load_satellites(
         self, tle_file: str | Path, frequency_file: str | Path | None = None
-    ) -> "ConfigurationBuilder":
+    ) -> ConfigurationBuilder:
         self.satellites = load_satellites(
             tle_file=Path(tle_file),
             frequency_file=Path(frequency_file) if frequency_file else None,
@@ -120,7 +125,7 @@ class ConfigurationBuilder:
         time_resolution_seconds: float = 1,
         concurrency_level: int = 1,
         min_altitude: float = 0.0,
-    ) -> "ConfigurationBuilder":
+    ) -> ConfigurationBuilder:
         self.runtime_settings = RuntimeSettings(
             concurrency_level=concurrency_level,
             time_resolution_seconds=time_resolution_seconds,
@@ -132,7 +137,7 @@ class ConfigurationBuilder:
         self,
         config_file: Path,
         loader_class: type[ConfigFileLoaderBase] = ConfigFileLoaderJson,
-    ) -> "ConfigurationBuilder":
+    ) -> ConfigurationBuilder:
         loader = loader_class(filepath=config_file)
 
         self.frequency_range = loader.frequency_range
@@ -143,7 +148,7 @@ class ConfigurationBuilder:
 
         return self
 
-    def set_satellites_filter(self, filterer: Filterer) -> "ConfigurationBuilder":
+    def set_satellites_filter(self, filterer: Filterer) -> ConfigurationBuilder:
         self._filterer = filterer
         return self
 

--- a/src/sopp/ephemeris/base.py
+++ b/src/sopp/ephemeris/base.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import numpy as np
 import numpy.typing as npt
 
-from sopp.models.core import Position, TimeWindow
-from sopp.models.ground.facility import Facility
-from sopp.models.satellite.satellite import Satellite
-from sopp.models.satellite.trajectory import SatelliteTrajectory
+if TYPE_CHECKING:
+    from sopp.models.core import Position, TimeWindow
+    from sopp.models.ground.facility import Facility
+    from sopp.models.satellite.satellite import Satellite
+    from sopp.models.satellite.trajectory import SatelliteTrajectory
 
 
 class EphemerisCalculator(ABC):

--- a/src/sopp/filtering/filterer.py
+++ b/src/sopp/filtering/filterer.py
@@ -1,6 +1,10 @@
-from collections.abc import Callable
+from __future__ import annotations
 
-from sopp.models.satellite.satellite import Satellite
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sopp.models.satellite.satellite import Satellite
 
 
 class Filterer:

--- a/src/sopp/models/configuration.py
+++ b/src/sopp/models/configuration.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from sopp.models.ground.config import AntennaConfig
-from sopp.models.reservation import Reservation
-from sopp.models.satellite.satellite import Satellite
+
+if TYPE_CHECKING:
+    from sopp.models.reservation import Reservation
+    from sopp.models.satellite.satellite import Satellite
 
 
 @dataclass

--- a/src/sopp/models/reservation.py
+++ b/src/sopp/models/reservation.py
@@ -1,7 +1,11 @@
-from dataclasses import dataclass
+from __future__ import annotations
 
-from sopp.models.core import FrequencyRange, TimeWindow
-from sopp.models.ground.facility import Facility
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sopp.models.core import FrequencyRange, TimeWindow
+    from sopp.models.ground.facility import Facility
 
 """
 The Reservation class stores the Facility, as well as some additional reservation-specific information, such as reservation start and end times.

--- a/src/sopp/models/satellite/satellite.py
+++ b/src/sopp/models/satellite/satellite.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 import math
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from skyfield.sgp4lib import EarthSatellite
 
-from sopp.models.core import FrequencyRange
-from sopp.models.satellite.tle import TleInformation
+if TYPE_CHECKING:
+    from sopp.models.core import FrequencyRange
+    from sopp.models.satellite.tle import TleInformation
 
 NUMBER_OF_LINES_PER_TLE_OBJECT = 3
 

--- a/src/sopp/pointing/base.py
+++ b/src/sopp/pointing/base.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from sopp.models.core import TimeWindow
-from sopp.models.ground.facility import Facility
-from sopp.models.ground.target import ObservationTarget
-from sopp.models.ground.trajectory import AntennaTrajectory
+if TYPE_CHECKING:
+    from sopp.models.core import TimeWindow
+    from sopp.models.ground.facility import Facility
+    from sopp.models.ground.target import ObservationTarget
+    from sopp.models.ground.trajectory import AntennaTrajectory
 
 
 class PointingCalculator(ABC):


### PR DESCRIPTION
## Summary

Apply the `from __future__ import annotations` import and `TYPE_CHECKING` pattern consistently across `src/sopp/` to improve import performance and enable forward references.

### Technical Details

* **`from __future__ import annotations`** makes all type annotations strings at runtime, avoiding evaluation at import time. This enables forward references without quotes and reduces import-time overhead.

* **`TYPE_CHECKING` block** allows imports that are only used in type hints to be skipped at runtime. These imports are only evaluated by type checkers, improving startup performance and avoiding circular import issues.