### PR TITLE
 ci: Add docs build check, faster example tests, fix Python matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,20 @@ jobs:
           pip install hatch
       - name: Run tests
         run: hatch run ci:run
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Build docs
+        run: hatch run docs:build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.ci]
 template = "test"
+python = ""
 dev-mode = false
 
 [tool.hatch.envs.docs]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,24 +1,53 @@
 """Smoke tests for example scripts to ensure they stay in sync with the API."""
 
-import shutil
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 REPO_ROOT = EXAMPLES_DIR.parent
-TEST_TLE = Path(__file__).parent / "io" / "load_satellites" / "satellites.tle"
 
 
 def _run_example(name: str):
     """Run an example script and assert it exits cleanly."""
     script = EXAMPLES_DIR / name
-    env = {**__import__("os").environ, "MPLBACKEND": "Agg"}
+    env = {**os.environ, "MPLBACKEND": "Agg"}
     result = subprocess.run(
         [sys.executable, str(script)],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=30,
+        cwd=str(REPO_ROOT),
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"{name} failed with exit code {result.returncode}:\n"
+        f"STDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+
+
+def _run_example_with_mock_sopp(name: str):
+    """Run an example with SOPP engine mocked to return empty results."""
+    script = EXAMPLES_DIR / name
+    env = {**os.environ, "MPLBACKEND": "Agg"}
+    wrapper = (
+        "from unittest.mock import patch, MagicMock; "
+        "from sopp.models.satellite.trajectory_set import TrajectorySet; "
+        "empty = TrajectorySet([]); "
+        "p1 = patch('sopp.sopp.Sopp.get_satellites_above_horizon', return_value=empty); "
+        "p2 = patch('sopp.sopp.Sopp.get_satellites_crossing_main_beam', return_value=empty); "
+        "p3 = patch('sopp.config.builder.ConfigurationBuilder.load_satellites', return_value=MagicMock()); "
+        "p1.start(); p2.start(); p3.start(); "
+        f"exec(open('{script}').read()); "
+        "p1.stop(); p2.stop(); p3.stop()"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", wrapper],
+        capture_output=True,
+        text=True,
+        timeout=30,
         cwd=str(REPO_ROOT),
         env=env,
     )
@@ -30,17 +59,7 @@ def _run_example(name: str):
 
 
 def test_example_runs():
-    """Copies a test TLE to the repo root if needed, then runs the example."""
-    tle_dest = REPO_ROOT / "satellites.tle"
-    created = False
-    if not tle_dest.exists():
-        shutil.copy(TEST_TLE, tle_dest)
-        created = True
-    try:
-        _run_example("example.py")
-    finally:
-        if created:
-            tle_dest.unlink()
+    _run_example_with_mock_sopp("example.py")
 
 
 def test_example_persistence_runs():
@@ -52,14 +71,4 @@ def test_example_link_budget_runs():
 
 
 def test_example_planning_runs():
-    """Copies a test TLE to the repo root if needed, then runs the planning example."""
-    tle_dest = REPO_ROOT / "satellites.tle"
-    created = False
-    if not tle_dest.exists():
-        shutil.copy(TEST_TLE, tle_dest)
-        created = True
-    try:
-        _run_example("example_planning.py")
-    finally:
-        if created:
-            tle_dest.unlink()
+    _run_example_with_mock_sopp("example_planning.py")


### PR DESCRIPTION
## Summary

Three CI improvements: add docs build to PR checks, mock SOPP engine in example smoke tests for faster runs and fix the Python version matrix so tests actually run on 3.10/3.11/3.12 instead of 3.11 three times.

### Changes

* `.github/workflows/ci.yml`: Add `docs` job that runs `hatch run docs:build` in strict mode
* `tests/test_examples.py`: Mock `Sopp` engine and `load_satellites` so example smoke tests don't need TLE files or orbital computation
* `pyproject.toml`: Set `python = ""` on `ci` env so hatch uses the system Python from the Actions matrix instead of inheriting `3.11` from the default env
