### PR TITLE
 refactor: Move frequency range from Reservation to Receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ from sopp.sopp import Sopp
 config = (
     ConfigurationBuilder()
     .set_facility(
-        latitude=40.8, longitude=-121.4, elevation=986, name="HCRO",
+        latitude=40.8,
+        longitude=-121.4,
+        elevation=986,
+        name="HCRO",
         receiver=Receiver(beamwidth=3),
     )
     .set_runtime_settings(concurrency_level=4)

--- a/benchmarks/benchmark_above_horizon.py
+++ b/benchmarks/benchmark_above_horizon.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from sopp.config.builder import ConfigurationBuilder
 from sopp.io.tle import load_satellites
+from sopp.models.ground.receiver import Receiver
 from sopp.sopp import Sopp
 from sopp.utils.helpers import read_datetime_string_as_utc
 
@@ -43,7 +44,7 @@ def run_benchmark(
             longitude=-121.4695413,
             elevation=986,
             name="HCRO",
-            beamwidth=3,
+            receiver=Receiver(beamwidth=3),
         )
         .set_frequency_range(bandwidth=10, frequency=135)
         .set_time_window(

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,10 @@ from sopp.sopp import Sopp
 config = (
     ConfigurationBuilder()
     .set_facility(
-        latitude=40.8178, longitude=-121.4695, elevation=986, name="HCRO",
+        latitude=40.8178,
+        longitude=-121.4695,
+        elevation=986,
+        name="HCRO",
         receiver=Receiver(beamwidth=3),
     )
     .set_time_window(begin="2026-01-13T19:00:00", end="2026-01-13T20:00:00")

--- a/examples/example.py
+++ b/examples/example.py
@@ -40,7 +40,9 @@ def main():
     )
     print(f"Reservation start time: {configuration.reservation.time.begin}")
     print(f"Reservation end time: {configuration.reservation.time.end}")
-    print(f"Observation frequency: {configuration.reservation.frequency.frequency} MHz")
+    print(
+        f"Observation frequency: {configuration.reservation.facility.receiver.frequency.frequency} MHz"
+    )
 
     # Determine Satellite Interference
     sopp = Sopp(configuration=configuration)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ deploy = "mkdocs gh-deploy --force"
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
-  "ruff",
+  "ruff~=0.16.2",
 ]
 
 [tool.hatch.envs.lint.scripts]

--- a/src/sopp/cli.py
+++ b/src/sopp/cli.py
@@ -343,7 +343,7 @@ def _print_summary(configuration, sat_count):
     console.print(
         Panel(
             f"{res.facility}\n"
-            f"{res.frequency}\n"
+            f"{res.facility.receiver.frequency or 'No frequency set'}\n"
             f"Time: {res.time.begin} -> {res.time.end}\n"
             f"[bold]Satellites Loaded:[/bold] {sat_count}",
             title="Simulation Parameters",

--- a/src/sopp/config/builder.py
+++ b/src/sopp/config/builder.py
@@ -201,7 +201,6 @@ class ConfigurationBuilder:
         """
         facility = self.facility
         time_window = self.time_window
-        frequency = self.frequency_range
         satellites = self.satellites
         antenna_config = self.antenna_config
 
@@ -212,12 +211,15 @@ class ConfigurationBuilder:
         if satellites is None:
             raise ValueError("Configuration invalid: Satellites are not loaded.")
 
+        # Apply frequency to receiver if set via set_frequency_range()
+        if self.frequency_range is not None:
+            facility.receiver.frequency = self.frequency_range
+
         filtered_satellites = self._filterer.apply_filters(satellites)
 
         reservation = Reservation(
             facility=facility,
             time=time_window,
-            frequency=frequency,
         )
 
         return Configuration(

--- a/src/sopp/models/ground/receiver.py
+++ b/src/sopp/models/ground/receiver.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sopp.models.antenna import AntennaPattern
+    from sopp.models.core import FrequencyRange
 
 
 @dataclass
@@ -24,11 +25,13 @@ class Receiver:
         beamwidth: Beamwidth of the telescope in degrees.
         peak_gain_dbi: Peak antenna gain in dBi (Tier 1). Defaults to None.
         antenna_pattern: Full antenna gain pattern (Tier 1.5+). Defaults to None.
+        frequency: Observation frequency range in MHz. Defaults to None.
     """
 
     beamwidth: float = 3.0
     peak_gain_dbi: float | None = None
     antenna_pattern: AntennaPattern | None = None
+    frequency: FrequencyRange | None = None
 
     def __post_init__(self):
         if self.beamwidth <= 0:
@@ -42,6 +45,8 @@ class Receiver:
         lines = [
             f"  Beamwidth:          {self.beamwidth} degrees",
         ]
+        if self.frequency is not None:
+            lines.append(f"  Frequency:          {self.frequency.frequency} MHz")
         if self.antenna_pattern is not None:
             lines.append(
                 f"  Peak Gain:          {self.antenna_pattern.peak_gain_dbi} dBi (from pattern)"

--- a/src/sopp/models/reservation.py
+++ b/src/sopp/models/reservation.py
@@ -1,12 +1,12 @@
-"""Observation reservation combining facility, time, and frequency."""
+"""Observation reservation combining facility and time."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from sopp.models.core import FrequencyRange, TimeWindow
+    from sopp.models.core import TimeWindow
     from sopp.models.ground.facility import Facility
 
 
@@ -17,19 +17,10 @@ class Reservation:
     Attributes:
         facility: The radio astronomy facility.
         time: Time window of the observation.
-        frequency: Frequency band being observed. Optional for horizon-only queries.
     """
 
     facility: Facility
     time: TimeWindow
-    frequency: FrequencyRange | None = field(default=None)
 
     def __str__(self):
-        parts = [
-            f"{self.__class__.__name__}:",
-            str(self.facility),
-            str(self.time),
-        ]
-        if self.frequency is not None:
-            parts.append(str(self.frequency))
-        return "\n".join(parts)
+        return f"{self.__class__.__name__}:\n{self.facility}\n{self.time}"

--- a/src/sopp/sopp.py
+++ b/src/sopp/sopp.py
@@ -138,7 +138,8 @@ class Sopp:
                 "analyze() requires antenna_config. Set an observation target, "
                 "static position, or custom trajectory in the configuration."
             )
-        if self.configuration.reservation.frequency is None:
+        facility = self.configuration.reservation.facility
+        if facility.receiver.frequency is None:
             raise ValueError(
                 "analyze() requires frequency_range. Set it via "
                 "ConfigurationBuilder.set_frequency_range()."
@@ -147,8 +148,8 @@ class Sopp:
             trajectories=trajectories,
             antenna_trajectory=self.antenna_trajectory,
             strategy=strategy,
-            facility=self.configuration.reservation.facility,
-            frequency=self.configuration.reservation.frequency,
+            facility=facility,
+            frequency=facility.receiver.frequency,
         )
 
     def _compute_trajectories_parallel(

--- a/src/sopp/tardys/tardys4.py
+++ b/src/sopp/tardys/tardys4.py
@@ -84,11 +84,11 @@ class Tardys4Generator:
 
     @property
     def _freq_start_hz(self) -> int:
-        return int(self._reservation.frequency.low_mhz * 10**6)
+        return int(self._reservation.facility.receiver.frequency.low_mhz * 10**6)
 
     @property
     def _freq_end_hz(self) -> int:
-        return int(self._reservation.frequency.high_mhz * 10**6)
+        return int(self._reservation.facility.receiver.frequency.high_mhz * 10**6)
 
     @cached_property
     def _time(self) -> str:

--- a/tests/analysis/test_interference.py
+++ b/tests/analysis/test_interference.py
@@ -36,7 +36,7 @@ def test_satellite_inside_beam_is_detected(
         antenna_trajectory=ant_traj,
         strategy=GeometricStrategy(),
         facility=reservation.facility,
-        frequency=reservation.frequency,
+        frequency=reservation.facility.receiver.frequency,
     )
 
     assert len(results) == 1
@@ -73,7 +73,7 @@ def test_satellite_outside_beam_is_ignored(
         antenna_trajectory=ant_traj,
         strategy=GeometricStrategy(),
         facility=reservation.facility,
-        frequency=reservation.frequency,
+        frequency=reservation.facility.receiver.frequency,
     )
 
     assert len(results) == 0
@@ -115,7 +115,7 @@ def test_satellite_enters_and_exits_beam(
         antenna_trajectory=ant_traj,
         strategy=GeometricStrategy(),
         facility=reservation.facility,
-        frequency=reservation.frequency,
+        frequency=reservation.facility.receiver.frequency,
     )
 
     assert len(results) == 1

--- a/tests/config/test_configuration_builder.py
+++ b/tests/config/test_configuration_builder.py
@@ -35,17 +35,15 @@ def expected_reservation():
     return Reservation(
         facility=Facility(
             coordinates=Coordinates(longitude=-1, latitude=1),
-            receiver=Receiver(beamwidth=3),
+            receiver=Receiver(
+                beamwidth=3, frequency=FrequencyRange(bandwidth=10, frequency=135)
+            ),
             elevation=1,
             name="HCRO",
         ),
         time=TimeWindow(
             begin=datetime(2023, 11, 15, 8, 0, tzinfo=timezone.utc),
             end=datetime(2023, 11, 15, 8, 30, tzinfo=timezone.utc),
-        ),
-        frequency=FrequencyRange(
-            bandwidth=10,
-            frequency=135,
         ),
     )
 
@@ -65,7 +63,7 @@ class StubConfigFileLoader(ConfigFileLoaderBase):
 
     @property
     def frequency_range(self):
-        return expected_reservation().frequency
+        return expected_reservation().facility.receiver.frequency
 
     @property
     def runtime_settings(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from sopp.models.configuration import Configuration, RuntimeSettings
 from sopp.models.core import Coordinates, FrequencyRange, Position, TimeWindow
 from sopp.models.ground.config import CustomTrajectoryConfig
 from sopp.models.ground.facility import Facility
+from sopp.models.ground.receiver import Receiver
 from sopp.models.ground.trajectory import AntennaTrajectory
 from sopp.models.reservation import Reservation
 from sopp.models.satellite import InternationalDesignator, MeanMotion, TleInformation
@@ -75,8 +76,11 @@ def arbitrary_datetime():
 
 
 @pytest.fixture
-def facility():
-    return Facility(coordinates=Coordinates(latitude=0, longitude=0))
+def facility(frequency_range):
+    return Facility(
+        coordinates=Coordinates(latitude=0, longitude=0),
+        receiver=Receiver(frequency=frequency_range),
+    )
 
 
 @pytest.fixture
@@ -116,9 +120,11 @@ def frequency_range():
 @pytest.fixture
 def reservation(start_time, time_window_duration, frequency_range):
     return Reservation(
-        facility=Facility(coordinates=Coordinates(latitude=0, longitude=0)),
+        facility=Facility(
+            coordinates=Coordinates(latitude=0, longitude=0),
+            receiver=Receiver(frequency=frequency_range),
+        ),
         time=TimeWindow(begin=start_time, end=start_time + time_window_duration),
-        frequency=frequency_range,
     )
 
 
@@ -183,7 +189,6 @@ def make_reservation(facility):
         return Reservation(
             facility=facility,
             time=window,
-            frequency=frequency_range,
         )
 
     return _make

--- a/tests/models/test_str.py
+++ b/tests/models/test_str.py
@@ -41,13 +41,14 @@ def test_facility(facility):
         "  Latitude:           10\n"
         "  Longitude:          10\n"
         "  Elevation:          1000 meters\n"
-        "  Beamwidth:          3 degrees"
+        "  Beamwidth:          3 degrees\n"
+        "  Frequency:          10 MHz"
     )
     assert str(facility) == expected
 
 
 def test_reservation(reservation):
-    expected = f"Reservation:\n{reservation.facility}\n{reservation.time}\n{reservation.frequency}"
+    expected = f"Reservation:\n{reservation.facility}\n{reservation.time}"
     assert str(reservation) == expected
 
 
@@ -77,18 +78,18 @@ def runtime_settings():
 
 
 @pytest.fixture
-def facility():
+def facility(frequency_range):
     return Facility(
         coordinates=Coordinates(10, 10),
-        receiver=Receiver(beamwidth=3),
+        receiver=Receiver(beamwidth=3, frequency=frequency_range),
         elevation=1000,
         name="TestFacility",
     )
 
 
 @pytest.fixture
-def reservation(facility, time_window, frequency_range):
-    return Reservation(facility, time_window, frequency_range)
+def reservation(facility, time_window):
+    return Reservation(facility=facility, time=time_window)
 
 
 @pytest.fixture

--- a/tests/tardys/test_tardys4_generator.py
+++ b/tests/tardys/test_tardys4_generator.py
@@ -1,5 +1,6 @@
 from sopp.models.core import Coordinates, FrequencyRange, TimeWindow
 from sopp.models.ground.facility import Facility
+from sopp.models.ground.receiver import Receiver
 from sopp.models.reservation import Reservation
 from sopp.tardys.tardys4 import Tardys4Generator
 from sopp.utils.helpers import parse_time_and_convert_to_utc
@@ -12,6 +13,7 @@ class TestTards4Generator:
                 latitude=40.8178049,
                 longitude=-121.4695413,
             ),
+            receiver=Receiver(frequency=FrequencyRange(frequency=1575, bandwidth=20)),
             elevation=986,
             name="HCRO",
         )
@@ -27,7 +29,6 @@ class TestTards4Generator:
         reservation = Reservation(
             facility=facility,
             time=time_window,
-            frequency=FrequencyRange(frequency=1575, bandwidth=20),
         )
 
         generator = Tardys4Generator(

--- a/tests/test_sopp.py
+++ b/tests/test_sopp.py
@@ -158,11 +158,12 @@ class TestSopp:
         return Reservation(
             facility=Facility(
                 coordinates=Coordinates(latitude=40.8178049, longitude=-121.4695413),
-                receiver=Receiver(beamwidth=3.5),
+                receiver=Receiver(
+                    beamwidth=3.5, frequency=FrequencyRange(frequency=135, bandwidth=10)
+                ),
                 name="ARBITRARY_1",
             ),
             time=time_window,
-            frequency=FrequencyRange(frequency=135, bandwidth=10),
         )
 
     @property


### PR DESCRIPTION
## Summary

Moves the observation frequency range from `Reservation` to `Receiver`. A reservation now describes only where and when an observation happens (facility + time window); the band being observed is a property of the receiver hardware itself. This continues the receiver modeling work from #133, which introduced the `Receiver` model on `Facility`.

### Technical Details

* `ConfigurationBuilder.set_frequency_range()` keeps its existing signature; `build()` now applies the value to `facility.receiver.frequency` instead of storing it on the `Reservation`, so all builder-based code is unaffected.
* The only breaking surface is direct construction of `Reservation(frequency=...)`; all internal consumers now read `reservation.facility.receiver.frequency`.

### Changes

**Model Changes**

* `src/sopp/models/reservation.py`: Remove the `frequency` field; `Reservation` is now facility + time only.
* `src/sopp/models/ground/receiver.py`: Add `frequency: FrequencyRange | None` and include it in the receiver summary string.

**Engine & CLI**

* `src/sopp/sopp.py`: Read the frequency from `facility.receiver` for interference filtering.
* `src/sopp/tardys/tardys4.py`: Read low/high band edges from the receiver.

**Builder**

* `src/sopp/config/builder.py`: Apply the `set_frequency_range()` value to the receiver at `build()` time.

**Examples and Benchmarks**

* `examples/example.py`: Updated for the new field location.
* `benchmarks/benchmark_above_horizon.py`: Updated to the Receiver API from #133

### Testing

* Updated tests and fixtures for the new field location.
* Full test suite passes.