### PR TITLE
refactor: Build Skyfield satellites directly from SGP4 elements

### DIFF
--- a/src/sopp/models/satellite/satellite.py
+++ b/src/sopp/models/satellite/satellite.py
@@ -6,6 +6,7 @@ import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from skyfield.api import load
 from skyfield.sgp4lib import EarthSatellite
 
 if TYPE_CHECKING:
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from sopp.models.satellite.tle import TleInformation
     from sopp.models.satellite.transmitter import Transmitter
 
-NUMBER_OF_LINES_PER_TLE_OBJECT = 3
+_SKYFIELD_TIMESCALE = load.timescale()
 
 
 @dataclass
@@ -37,14 +38,21 @@ class Satellite:
         return self.tle_information.satellite_number
 
     def to_skyfield(self) -> EarthSatellite:
-        """Convert to a Skyfield EarthSatellite. Requires TLE data."""
+        """Convert to a Skyfield EarthSatellite. Requires orbital elements.
+
+        Builds the SGP4 propagator directly from the parsed elements, so
+        satellite numbers beyond the TLE format's field width work fine.
+        """
         if self.tle_information is None:
             raise ValueError(
                 f"Satellite '{self.name}' has no TLE data. "
                 "Cannot convert to Skyfield without orbital parameters."
             )
-        line1, line2 = self.tle_information.to_tle_lines()
-        return EarthSatellite(line1=line1, line2=line2, name=self.name)
+        earth_satellite = EarthSatellite.from_satrec(
+            self.tle_information.to_satrec(), _SKYFIELD_TIMESCALE
+        )
+        earth_satellite.name = self.name
+        return earth_satellite
 
     @property
     def orbits_per_day(self) -> float:

--- a/src/sopp/models/satellite/tle.py
+++ b/src/sopp/models/satellite/tle.py
@@ -2,10 +2,9 @@
 
 from dataclasses import dataclass
 
+from sgp4.api import WGS72, Satrec
 from sgp4.exporter import export_tle
 from sgp4.io import verify_checksum
-from sgp4.model import Satrec
-from sgp4.vallado_cpp import WGS72
 
 
 @dataclass
@@ -69,7 +68,8 @@ class TleInformation:
     classification: str = "U"
     international_designator: InternationalDesignator | None = None
 
-    def to_tle_lines(self):
+    def to_satrec(self) -> Satrec:
+        """Build an SGP4 Satrec propagator directly from the stored elements."""
         satrec = Satrec()
         satrec.sgp4init(
             WGS72,
@@ -94,12 +94,25 @@ class TleInformation:
         )
         satrec.revnum = self.revolution_number
 
-        return export_tle(satrec=satrec)
+        return satrec
+
+    def to_tle_lines(self):
+        """Export as TLE lines.
+
+        The TLE satellite number field is 5 characters, so plain digits
+        stop at 99999. sgp4 also writes the Alpha-5 extension, where a
+        leading letter counts as 10-33 ("A0000" is satellite 100000,
+        "Z9999" is 339999). Larger numbers raise ValueError.
+        """
+        return export_tle(satrec=self.to_satrec())
 
     @classmethod
     def from_tle_lines(cls, line1: str, line2: str) -> "TleInformation":
         verify_checksum(line1, line2)
-        satrec = Satrec.twoline2rv(line1=line1, line2=line2)
+        return cls.from_satrec(Satrec.twoline2rv(line1, line2))
+
+    @classmethod
+    def from_satrec(cls, satrec: Satrec) -> "TleInformation":
         international_designator = (
             InternationalDesignator.from_tle_string(satrec.intldesg)
             if satrec.intldesg

--- a/tests/models/satellite/test_satellite_to_skyfield.py
+++ b/tests/models/satellite/test_satellite_to_skyfield.py
@@ -1,12 +1,26 @@
-import pickle
-import re
-import types
+from dataclasses import replace
 
+import numpy as np
+import pytest
 from skyfield.api import EarthSatellite
 
 from tests.models.satellite.utilities import (
     expected_international_space_station_tle_as_satellite_cu,
 )
+
+EXACT_MODEL_ATTRIBUTES = ["satnum", "classification", "intldesg", "revnum"]
+FLOAT_MODEL_ATTRIBUTES = [
+    "argpo",
+    "bstar",
+    "ecco",
+    "inclo",
+    "mo",
+    "ndot",
+    "nddot",
+    "no_kozai",
+    "nodeo",
+]
+SIX_DIGIT_SATELLITE_NUMBER = 100000
 
 
 class TestSatelliteToSkyfield:
@@ -30,31 +44,59 @@ class TestSatelliteToSkyfield:
         self._converted_satellite = self._cu_satellite.to_skyfield()
 
     def then_the_satellites_should_match(self) -> None:
-        assert self._models_match() and self._non_model_properties_match()
+        assert self._converted_satellite.name == self._skyfield_satellite.name
+        assert self._models_match()
+        assert self._epochs_match()
+        assert self._propagated_positions_match()
 
     def _models_match(self) -> bool:
-        for attribute in dir(self._converted_satellite.model):
-            built_satellite_value = getattr(self._converted_satellite.model, attribute)
-            should_test_attribute = not re.compile("^_").match(attribute) and type(
-                built_satellite_value
-            ) not in [types.BuiltinMethodType, types.MethodType]
-            if should_test_attribute and built_satellite_value != getattr(
-                self._skyfield_satellite.model, attribute
-            ):
-                return False
-        return True
+        built = self._converted_satellite.model
+        expected = self._skyfield_satellite.model
 
-    def _non_model_properties_match(self) -> bool:
-        built_satellite_model = self._converted_satellite.model
-        expected_satellite_model = self._skyfield_satellite.model
-        self._converted_satellite.model = None
-        self._skyfield_satellite.model = None
+        exact_match = all(
+            getattr(built, attribute) == getattr(expected, attribute)
+            for attribute in EXACT_MODEL_ATTRIBUTES
+        )
+        float_match = all(
+            getattr(built, attribute)
+            == pytest.approx(getattr(expected, attribute), rel=1e-12)
+            for attribute in FLOAT_MODEL_ATTRIBUTES
+        )
+        return exact_match and float_match
 
-        is_match = pickle.dumps(self._converted_satellite) == pickle.dumps(
-            self._skyfield_satellite
+    def _epochs_match(self) -> bool:
+        built = self._converted_satellite.model
+        expected = self._skyfield_satellite.model
+
+        built_epoch = built.jdsatepoch + built.jdsatepochF
+        expected_epoch = expected.jdsatepoch + expected.jdsatepochF
+        return built_epoch == pytest.approx(expected_epoch, abs=1e-8)
+
+    def _propagated_positions_match(self) -> bool:
+        epoch = self._skyfield_satellite.epoch
+        times = epoch.ts.tt_jd(epoch.tt + np.linspace(0, 1, 5))
+
+        built_positions = self._converted_satellite.at(times).position.km
+        expected_positions = self._skyfield_satellite.at(times).position.km
+        return np.allclose(built_positions, expected_positions, rtol=0, atol=1e-3)
+
+
+class TestSatelliteToSkyfieldSixDigitNoradId:
+    def test_six_digit_norad_id_can_translate_to_skyfield(self):
+        """NORAD IDs above 99999 no longer fit the TLE format; conversion
+        to Skyfield must not round-trip through TLE lines."""
+        satellite = expected_international_space_station_tle_as_satellite_cu()
+        tle_information = satellite.tle_information
+        assert tle_information is not None
+        satellite = replace(
+            satellite,
+            tle_information=replace(
+                tle_information, satellite_number=SIX_DIGIT_SATELLITE_NUMBER
+            ),
         )
 
-        self._converted_satellite.model = built_satellite_model
-        self._skyfield_satellite.model = expected_satellite_model
+        skyfield_satellite = satellite.to_skyfield()
 
-        return is_match
+        assert skyfield_satellite.model.satnum == SIX_DIGIT_SATELLITE_NUMBER
+        geocentric = skyfield_satellite.at(skyfield_satellite.epoch)
+        assert np.isfinite(geocentric.position.km).all()


### PR DESCRIPTION
## Summary

`Satellite.to_skyfield()` used to serialize the parsed orbital elements back into TLE text and have Skyfield re-parse that text into a propagator. The NORAD catalog crossed 69999 in July 2026, and newly cataloged satellites have 6-digit IDs that cannot pass through the TLE format's fixed 5-character satellite number field. This PR builds the SGP4 propagator directly from the stored elements and hands it to Skyfield, removing the text round trip so satellite numbers of any width propagate correctly.

Additionally, lays the groundwork for OMM ingestion: any loader that produces a `Satrec` can now construct a `TleInformation`.

### Technical Details

* `TleInformation` gains `to_satrec()` and `from_satrec()`, extracted from the existing `to_tle_lines()`/`from_tle_lines()` bodies; the TLE methods delegate to them and behave as before.
* `Satellite.to_skyfield()` now uses `EarthSatellite.from_satrec()` with a Skyfield timescale.
* sgp4 imports moved from `sgp4.model` to `sgp4.api` so the `Satrec` handed to Skyfield is the C++ accelerated implementation; previously the accelerated propagator was created by Skyfield itself while re-parsing the text.
* The above-horizon benchmark (2000 satellites, 6 hours) shows performance parity with main.

### Changes

**Model Changes**

* `src/sopp/models/satellite/tle.py`: Extract `to_satrec()` and `from_satrec()`; import `Satrec`/`WGS72` from `sgp4.api`.
* `src/sopp/models/satellite/satellite.py`: Build the Skyfield satellite via `from_satrec()` and add a module-level timescale; remove an unused TLE line-count constant.

### Testing

* Added a regression test for 6-digit satellite number (100000) converts and propagates.
